### PR TITLE
Update EnhancedSteam dropdown to disappear

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ v3.7
 : Fixed a bug where background selection was showing on profile security page
 + Added "help" question mark next to options that links to the feature on enhancedsteam.com
 : Changed changelog textarea to be readonly
+: Changed "Enhanced Steam" dropdown to disappear if user clicks somewhere
 
 v3.6
 -----

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -607,10 +607,19 @@ function find_purchase_date(appname) {
 
 // Adds a link to options to the global menu (where is Install Steam button)
 function add_enhanced_steam_options() {
-	$dropdown = $("<span class=\"pulldown\" id=\"account_pulldown\">Enhanced Steam</span>");
+	$dropdown = $("<span class=\"pulldown\" id=\"enhanced_pulldown\">Enhanced Steam</span>");
 	$dropdown_options_container = $("<div class=\"popup_block\"><div class=\"popup_body popup_menu\"></div></div>");
 	$dropdown_options = $dropdown_options_container.find(".popup_body");
 	$dropdown_options.css("display", "none");
+
+	// remove menu if click anywhere but on "Enhanced Steam". Commented out bit is for clicking on menu won't make it disappear either.
+	$('body').bind('click', function(e) {
+		if(/*$(e.target).closest(".popup_body").length == 0 && */$(e.target).closest("#enhanced_pulldown").length == 0) {
+			if ($dropdown_options.css("display") == "block" || $dropdown_options.css("display") == "") {
+				$dropdown_options.css("display", "none");
+			}
+		}
+	});
 
 	$dropdown.click(function(){
 		if ($dropdown_options.css("display") === "none") {


### PR DESCRIPTION
Added function such that if you click anywhere on the page, the dropdown will disappear (includes inside the menu itself). This adds to the current functionality of it appearing/disappearing if you click on the menu header ("Enhanced Steam"). Commented out bit of code would make it so it wouldn't appear if you clicked a menu item. A simple stylistic change I thought would be nice.
