### PR TITLE
Purchase Date for games can be incorrect if you later purchase/activate a store item that starts with the game name.

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -605,13 +605,14 @@ function empty_wishlist() {
 
 function find_purchase_date(appname) {
 	get_http('http://store.steampowered.com/account/', function (txt) {
-		var apphtml = txt.substring(txt.indexOf('<div class="transactionRowTitle">' + appname), txt.indexOf('<div class="transactionRowTitle">' + appname) - 300);
-		var appdate = apphtml.match(/<div class="transactionRowDate">(.+)<\/div>/);
+		var earliestPurchase = $(txt).find("#store_transactions .transactionRowTitle:contains(" + appname + ")").closest(".transactionRow").last(),
+			purchaseDate = $(earliestPurchase).find(".transactionRowDate").text();
+
 		var found = 0;
 		xpath_each("//div[contains(@class,'game_area_already_owned')]", function (node) {
 			if (found === 0) {
-				if (appdate) {
-					node.innerHTML = node.innerHTML + localized_strings[language].purchase_date.replace("__date__", appdate[1]);
+				if (purchaseDate) {
+					node.innerHTML = node.innerHTML + localized_strings[language].purchase_date.replace("__date__", purchaseDate);
 					found = 1;
 				}
 			}


### PR DESCRIPTION
## Problem
- I activated "Dota 2 Beta" on 30 Sep 2011.
  ![2](https://f.cloud.github.com/assets/602850/774366/50ae1004-e956-11e2-89dc-6e359fac5914.png)
- I activated "Dota 2 + Portal 2 Soundtrack Bundle Retail" on 13 Nov 2012.
  ![3](https://f.cloud.github.com/assets/602850/774367/50b65a7a-e956-11e2-80f8-30fdc3b03421.png)
- Dota 2 store page displays "13 Nov 2012" as purchase date.
  ![1](https://f.cloud.github.com/assets/602850/774368/50c06592-e956-11e2-9e1d-5e5afd4cdb4e.png)
## Proposed solution / what the pull request does.

Return the earliest (last in list) instance of an app's name from the "Store Transactions" list, rather than the current implementation which just searches for the first `'<div class="transactionRowTitle">' + appname` in the whole pages text.  The pull request accomplishes this (as well as remove trailing whitespace because my editor is addicted to eating the stuff).
