### PR TITLE
exclude 'ANGEBOT DES TAGES' (i.e. daily deal) from Tages-protected games

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -1059,6 +1059,7 @@ function drm_warnings() {
 			if (document.body.innerHTML.indexOf("Tages") > 0) { tages = true; }
 			if (document.body.innerHTML.indexOf("Angebote des Tages") > 0) { tages = false; }
 			if (document.body.innerHTML.indexOf("TAGES") > 0) { tages = true; }
+			if (document.body.innerHTML.indexOf("ANGEBOT DES TAGES") > 0) { tages = false; }
 			if (document.body.innerHTML.indexOf("SOLIDSHIELD") > 0) { tages = true; }
 			if (document.body.innerHTML.indexOf("Solidshield Tages") > 0) { tages = true; }
 			if (document.body.innerHTML.indexOf("Tages Solidshield") > 0) { tages = true; }


### PR DESCRIPTION
As all Summer Sale daily deals have "ANGEBOT DES TAGES" on them, this patch aims to skip those.

I'm not entirely sure the current approach is good in the long run, as TAGES-protected games could pop up in the long run - so eventually, either not enough or too many games could be marked incorrectly.
