### PR TITLE
Bug fix: "wish for" tag causes overlaps.

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -327,7 +327,7 @@ function display_tags(node) {
 
 			$tags.css("float", "right");
 			$tags.css("width", "130px");
-			$tags.css("margin-top", "4px");
+			$tags.css("margin-top", "30px");
 			$tag_root.find(".match_price").after($tags);
 		}
 		else if (node.classList.contains("cluster_capsule")) {


### PR DESCRIPTION
Activating "wish for" tag causes overlaps in search popup for some
entries (expecially for longer translated strings). Move the tag from
top-right to bottom-right corner works nice.

Example here: http://oi44.tinypic.com/2955onl.jpg
