### PR TITLE
Don't load ES on checkout or login pages (peace of mind thing)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,6 +19,11 @@
   "content_scripts": [
     {
       "matches": ["http://*.steampowered.com/*", "https://*.steampowered.com/*", "http://steamcommunity.com/*"],
+      "exclude_matches": [
+        "https://store.steampowered.com/checkout/*",
+        "https://store.steampowered.com/login/*",
+        "https://steamcommunity.com/login/*"
+      ],
       "js": [
         "js/jQuery.min.js",
         "js/localization.js",


### PR DESCRIPTION
Only a minor change in response to http://www.reddit.com/r/Steam/comments/1lwyg9/quick_question_dont_upvote_can_enhanced_steam_see/

ES doesn't do anything on these pages and they're known to contain sensitive information, so for the peace-of-mind of users I suggest we just don't allow the extension to load on them.
