### PR TITLE
prettifying game link highlighting + tags

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -1,22 +1,22 @@
-.popup_menu .hr {
-	height: 1px;
-	background-color: #82807c;
-	width: 90%;
-	margin: auto;
-}
-
-.es_highlight_owned {
+.blotter_author_block .es_highlight_owned {
 	border-color: rgb(92, 120, 54);
 	border-width: 0 0.2em 0 0.2em;
 	border-style: solid;
 	border-radius: 0.5em;
 }
 
-.es_highlight_wishlist {
+.blotter_author_block .es_highlight_wishlist {
 	border-color: rgb(73, 110, 147);
 	border-width: 0 0.2em 0 0.2em;
 	border-style: solid;
 	border-radius: 0.5em;
+}
+
+.popup_menu .hr {
+	height: 1px;
+	background-color: #82807c;
+	width: 90%;
+	margin: auto;
 }
 
 #es_library_list, #es_library_search {


### PR DESCRIPTION
(See: jshackles/Enhanced_Steam#183)

In both images, top is before, bottom is after.

Highlighting:
![Highlighting. Top is before, bottom is after.](https://f.cloud.github.com/assets/3758364/1234070/cd75e13e-2957-11e3-9b61-94f634d2a4df.png)

Tags:
![Tags. Top is before, bottom is after.](https://f.cloud.github.com/assets/3758364/1234074/84cad0b0-2958-11e3-94b1-6351ec968ed7.png)
