### PR TITLE
Fixed library games appending to each other.

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -1142,7 +1142,7 @@ function library_show_app(appid) {
 	get_http('http://store.steampowered.com/api/appdetails/?appids=' + appid, function (txt) {
 		var app_data = JSON.parse(txt);
 
-		if (app_data[appid].success) {
+		if (app_data[appid].success && appid == $('.es_library_selected').data('appid')) {
 
 			// fill background div with screenshot
 			var screenshotID = Math.floor(Math.random() * app_data[appid].data.screenshots.length - 1) + 1;
@@ -1312,7 +1312,7 @@ function library_show_app(appid) {
 				$("#es_library_app_links ul").append("<li><a href='" + app_data[appid].data.website + "'>Website</a></li>");
 			}
 		}
-		else {
+		else if(appid == $('.es_library_selected').data('appid')) {
 			$("#es_library_list_loading").html("App ID " + appid + " wasn't found.");
 		}
 	});


### PR DESCRIPTION
![Anomaly](http://i.imgur.com/Vu9u2Tf.png)
The library element gets reset before the async function, so if someone makes more than one request in a short period of time (before the previous request ends), the informations are merged together, resulting in the anomaly shown on the screenshot. 
This code makes sure that the downloaded data is for the currently selected game on the list, and runs the "creation" procedure only if it is. In case the request wasn't successful, it shows the usual "App not found" message, and in case the request was successful, but for another game, it basically gets discarded. The loading indicator stays until the proper game data gets downloaded, or in case it already was, nothing happens.

what did i write idonteven
