### PR TITLE
es_each css

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -459,13 +459,14 @@ img.platform_small, .platform_img {
 }
 .es_each {
 	text-decoration: none;
-	left:auto;
-	float:right;
+	text-align: center;
+	left: auto;
+	right: auto;
+	float: none;
 	position:relative;
 	font-family: tahoma, helvetica, arial, trebuchet ms, sans-serif;
 	color: #626366;
 	font-size: 11px;
-	right:14px;
 	top:-3px;
 }
 .es_each_price {


### PR DESCRIPTION
Current css is fixed for "each" text width. If translation is a bit larger the text is wrong centered. This fix it.
