### PR TITLE
Fixing an error caused by the Steam Summer Getaway Badge

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -4432,8 +4432,9 @@ function add_badge_view_options() {
 				}
 			}
 			if ($(this).find("div[class$='badge_progress_info']").text()) {
-				var card = $(this).find("div[class$='badge_progress_info']").text().trim().match(/(\d+)\D*(\d+)/)[1] + " / " + $(this).find("div[class$='badge_progress_info']").text().trim().match(/(\d+)\D*(\d+)/)[2];
-				$(this).find("div[class$='badge_progress_info']").text(card);
+				var card = $(this).find("div[class$='badge_progress_info']").text().trim().match(/(\d+)\D*(\d+)/),
+					text = (card) ? card[1] + " / " + card[2] : '';
+				$(this).find("div[class$='badge_progress_info']").text(text);
 			}
 		});
 


### PR DESCRIPTION
I have a complete Steam Summer Getaway Badge (gamecards/245070) resulting in no match being found for the following:
$(this).find("div[class$='badge_progress_info']").text().trim().match(/(\d+)\D*(\d+)/)

This was causing the page to break because the following wouldn't get run:
$(".es_steamcardexchange_link").remove();
$(".badges_sheet").css("text-align", "center");
$(".badges_sheet").css("margin-left", "32px");
$(".badge_empty").css("border", "none");
$("#footer_spacer").before('<div style="display: block; clear: both;"></div>');
