### PR TITLE
Added advanced page controls to inventory

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -2828,6 +2828,87 @@ function inventory_market_helper(response) {
 	}
 }
 
+function add_inventory_gotopage(){
+	$("#es_gotopage").remove();
+	var es_gotopage = document.createElement("script");
+	es_gotopage.type = "text/javascript";
+	es_gotopage.id = "es_gotopage";
+	es_gotopage.textContent =
+		["g_ActiveInventory.GoToPage = function(page){",
+		 "	var iCurPage = this.pageCurrent;",
+		 "	var iNextPage = Math.min(Math.max(0, --page), this.pageTotal-1);",
+		 "	this.pageList[iCurPage].hide();",
+		 "	this.pageList[iNextPage].show();",
+		 "	this.pageCurrent = iNextPage;",
+		 "	this.LoadPageImages(this.pageList[iNextPage]);",
+		 "	this.PreloadPageImages(iNextPage);",
+		 "	this.UpdatePageCounts();",
+		 "}",
+		 "function InventoryLastPage(){",
+		 "	g_ActiveInventory.GoToPage(g_ActiveInventory.pageTotal);",
+		 "}",
+		 "function InventoryFirstPage(){",
+		 "	g_ActiveInventory.GoToPage(1);",
+		 "}",
+		 "function InventoryGoToPage(){",
+		 "	var page = $('es_pagenumber').value;",
+		 "	if (isNaN(page)) return;",
+		 "	g_ActiveInventory.GoToPage(parseInt(page));",
+		 "}"].join('\n');
+
+	document.documentElement.appendChild(es_gotopage);
+
+	// Go to first page
+	var firstpage = document.createElement("a");
+	firstpage.textContent = "<<";
+	firstpage.id = "pagebtn_first";
+	firstpage.classList.add("pagecontrol_element");
+	firstpage.classList.add("pagebtn");
+	firstpage.href = "javascript:InventoryFirstPage();";
+	$("#pagebtn_previous").after(firstpage);
+
+	// Go to last page
+	var lastpage = document.createElement("a");
+	lastpage.textContent = ">>";
+	lastpage.id = "pagebtn_last";
+	lastpage.classList.add("pagecontrol_element");
+	lastpage.classList.add("pagebtn");
+	lastpage.href = "javascript:InventoryLastPage();";
+	$("#pagebtn_next").before(lastpage);
+
+	$(".pagebtn").css({
+		"padding": "0",
+		"width": "32px",
+		"margin": "0 3px"
+	});
+
+	// Page number box
+	var pagenumber = document.createElement("input");
+	pagenumber.type = "number";
+	pagenumber.value="1";
+	pagenumber.classList.add("filter_search_box"); //Steam's input theme
+	pagenumber.autocomplete = "off";
+	pagenumber.placeholder = "page #";
+	pagenumber.id = "es_pagenumber";
+	pagenumber.style.width = "50px";
+	$("#inventory_pagecontrols").before(pagenumber);
+
+	var goto_btn = document.createElement("a");
+	goto_btn.textContent = "Go";
+	goto_btn.id = "gotopage_btn";
+	goto_btn.classList.add("pagebtn");
+	goto_btn.href = "javascript:InventoryGoToPage();";
+	goto_btn.style.width = "32px";
+	goto_btn.style.padding = "0";
+	goto_btn.style.margin = "0 6px";
+	goto_btn.style.textAlign = "center";
+	$("#inventory_pagecontrols").before(goto_btn);
+
+	//TODO: Maybe use &laquo; or &#8810; for first/last button text?
+	//TODO: Disable buttons when already on first/last page?
+	//TODO: set .min and .max on pagenumber input?
+}
+
 function subscription_savings_check() {
 	var not_owned_games_prices = 0,
 		appid_info_deferreds = [],
@@ -4832,6 +4913,7 @@ $(document).ready(function(){
 					case /^\/(?:id|profiles)\/.+\/inventory/.test(window.location.pathname):
 						bind_ajax_content_highlighting();
 						inventory_market_prepare();
+						add_inventory_gotopage();
 						break;
 
 					case /^\/(?:id|profiles)\/(.+)\/games/.test(window.location.pathname):


### PR DESCRIPTION
In response to this issue: https://github.com/jshackles/Enhanced_Steam/issues/273

Added button to go to first page, last page, and to specific page.
Here is what it looks like: ![](http://i.imgur.com/rKpo3yT.png)
From the testing I've done, it all works fine. It does all the steps as normal page change does (such as image preloading), except the transition. It just teleports to the given page, which to me sounds reasonable.

There's a few potential tweaks that would be tricky to do.
1. Currently, first/last button don't get disabled if you are on the first/last page. To do this, you need to actually hook into the functions for NextPage and PreviousPage and it'd become much more of a hack job than it currently is.
2. The input currently has no min/max bounds, might want to add that. Then again, Firefox doesn't even support type="number" apparently? I do bound checks when changing the page though, so it's less important I guess.
3. I've experimented with various character for the first last button, such as « » or ≪ ≫. The problem is that they look so different from the original prev/next buttons, but we could change those too. I'll let you guys decide which looks best.
