### PR TITLE
Library: only jump into view if needed

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -1160,8 +1160,9 @@ function add_library_menu() {
 						$(".es_library_app[data-appid='" + settings.librarylastappid + "']").addClass('es_library_selected');
 						$("#es_library_list").data("appid-selected", settings.librarylastappid);
 						// scroll if found in the app list
-						if ($(".es_library_app[data-appid='" + settings.librarylastappid + "']").length != 0) {
-							$(".es_library_app[data-appid='" + settings.librarylastappid + "']")[0].scrollIntoView();
+						var selected = $(".es_library_app[data-appid='" + settings.librarylastappid + "']");
+						if (selected.length != 0) {
+							selected[0].scrollIntoViewIfNeeded();
 						}
 					}
 
@@ -1181,10 +1182,6 @@ function add_library_menu() {
 			else if (window.location.hash.startsWith("#library/app/")) {
 				showAppInLibrary();
 			}
-
-			$(".es_library_app").bind("click", function() {
-				showAppInLibrary();
-			});
 
 			$(window).bind("hashchange", function() {
 				if (window.location.hash == "#library") {


### PR DESCRIPTION
I don't know if it's just me, but the current game selection which moves the selected item to the top of the list feels very irritating. I wrote a whole check with offsets and height, only to find out that .scrollIntoViewIfNeeded(); did all that already. It seems a lot more usable to me like this, but feel free to ignore it if you disagree.

Also, I might be wrong, but binding to click seems useless, as you've already binded to hashchange, and clicking items will cause a hash change, so as is, you're executing the code twice I believe.
