### PR TITLE
 Use gulp to JSHint the project.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,9 @@ pip-log.txt
 
 # Mac crap
 .DS_Store
+
+#################
+## Node
+#################
+
+node_modules

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,27 @@
+{
+    "node": true,
+    "browser": true,
+    "esnext": true,
+    "bitwise": true,
+    "camelcase": true,
+    "curly": true,
+    "eqeqeq": true,
+    "immed": true,
+    "indent": 4,
+    "latedef": true,
+    "newcap": true,
+    "noarg": true,
+    "quotmark": "single",
+    "undef": true,
+    "unused": true,
+    "strict": true,
+    "trailing": true,
+    "smarttabs": true,
+    "jquery": true,
+    "globals": {
+        "define": true,
+        "jquery": true,
+        "require": true,
+        "requirejs": true
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - 0.10
+before_script:
+  - npm install

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var gulp = require('gulp');
+var jshint = require('gulp-jshint');
+
+var paths = {
+	scripts: ['enhancedsteam.js']
+};
+
+gulp.task('jshint', function() {
+	return gulp.src(paths.scripts)
+	    .pipe(jshint('.jshintrc'))
+        .pipe(jshint.reporter('default'));
+});
+
+// The default task (called when you run `gulp` from cli)
+gulp.task('default', ['jshint']);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "enhanced-steam",
+  "version": "6.2.0",
+  "description": "Enhances the Steam Experience",
+  "dependencies": {},
+  "scripts": {
+    "test": "gulp"
+  },
+  "devDependencies": {
+    "gulp": "~3.6",
+    "gulp-jshint": "~1.6.2"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  }
+}


### PR DESCRIPTION
Added a very simple gulpfile to JSHint the project, this ignores jQuery as we know this is already defined.

The `.jshintrc` contains linting rules, these can be changed.

`.travis-yml` enables CI builds like this: https://travis-ci.org/Saturate/sharepoint-forms-ext, when the projects uses UNIT Tests it will be easy to make it test these as well.

To install gulp please look at their website. You need to run `npm install` to install the dependencies defined in package.json

Longer down the road it would be a good idea to have a source folder, and a build folder that could be packaged for chrome ect. this way the project is more clean, especcialy if you are minizming the files via gulp.

Should also "fix" #443 

Questions / comments?
