### PR TITLE
Show platform for summersale.

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -6131,6 +6131,27 @@ function search_in_names_only(calledbyajax) {
 	}
 }
 
+// Show what platform games are for
+function show_win_mac_linux() {
+	if (window.location.host != "store.steampowered.com" || !(/^\/$/.test(window.location.pathname))) return;
+	$(".summersale_dailydeal:not(.tiny)").each(function () {
+		var node = $(this);
+		var id = get_appid(node.attr("href"));
+		if (!id) return;
+		get_http('http://store.steampowered.com/api/appdetails/?filters=platforms&appids=' + id, function (data) {
+			var storefront_data = JSON.parse(data);
+			var platforms = storefront_data[id]['data']['platforms'];
+			var footer = node.children(".dailydeal_footer").first();
+			var html = '<div style="padding: 2px">';
+			if (platforms['windows']) html += '<span class="platform_img win"></span>';
+			if (platforms['mac']) html += '<span class="platform_img mac"></span>';
+			if (platforms['linux']) html += '<span class="platform_img linux"></span>';
+			html += '</div>';
+			footer.prepend(html);
+		});
+	});
+}
+
 $(document).ready(function(){
 	is_signed_in();
 
@@ -6255,6 +6276,7 @@ $(document).ready(function(){
 						//add_affordable_button();
 						show_regional_pricing();
 						hide_unowned_game_dlc();
+						show_win_mac_linux();
 						break;
 				}
 


### PR DESCRIPTION
Made a simple change to show the platforms supported by the game during the summer sale.

![image](https://cloud.githubusercontent.com/assets/666420/3346376/9c76975c-f8c5-11e3-81b5-1c4b77bafce1.png)
