### PR TITLE
Fixed wishlist sortable

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -40,7 +40,6 @@ v6.6.1
 + Added basic support for upcomming store currencies
 : Updated SteamDB icon on store page buttons
 : Fixed a bug caused by Steam_Language cookie not being present for all users
->>>>>>> origin/dev
 
 v6.6
 -----


### PR DESCRIPTION
The price history element will follow the wishlist item during sorting.

This was done by wrapping the wishlist items into a containing div and recreating the sortables collection. Since the price history is inserted above the wishlist item, both elements will still be inside of the sortable container.
