### PR TITLE
Add an option to link directly to the inventory of the Steam Card Exchange bot

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -5541,12 +5541,18 @@ function get_gamecard(t) {
 function add_cardexchange_links(game) {
 	storage.get(function(settings) {
 		if (settings.steamcardexchange === undefined) { settings.steamcardexchange = true; storage.set({'steamcardexchange': settings.steamcardexchange}); }
+		if (settings.steamcardexchange_inv === undefined) { settings.steamcardexchange_inv = false; storage.set({'steamcardexchange_inv': settings.steamcardexchange_inv}); }
 		if (settings.steamcardexchange) {
 			$(".badge_row").each(function (index, node) {
 				var $node = $(node);
 				var gamecard = game || get_gamecard($node.find(".badge_row_overlay").attr('href'));
 				if(!gamecard) return;
-				$node.prepend('<div style="position: absolute; z-index: 3; top: 12px; right: 12px;" class="es_steamcardexchange_link"><a href="http://www.steamcardexchange.net/index.php?gamepage-appid-' + gamecard + '" target="_blank" alt="Steam Card Exchange" title="Steam Card Exchange"><img src="' + chrome.extension.getURL('img/ico/steamcardexchange.png') + '" width="24" height="24" border="0" /></a></div>');
+				if (settings.steamcardexchange_inv) {
+					var url = "http://www.steamcardexchange.net/index.php?inventorygame-appid-" + gamecard;
+				} else {
+					var url = "http://www.steamcardexchange.net/index.php?gamepage-appid-" + gamecard;
+				}
+				$node.prepend('<div style="position: absolute; z-index: 3; top: 12px; right: 12px;" class="es_steamcardexchange_link"><a href="' + url + '" target="_blank" alt="Steam Card Exchange" title="Steam Card Exchange"><img src="' + chrome.extension.getURL('img/ico/steamcardexchange.png') + '" width="24" height="24" border="0" /></a></div>');
 				$node.find(".badge_title_row").css("padding-right", "44px");
 			});
 		}

--- a/js/options.js
+++ b/js/options.js
@@ -140,6 +140,7 @@ function save_options() {
 	show_profile_link_images = $("#profile_link_images_dropdown").val();
 	
 	steamcardexchange = $("#steamcardexchange").prop('checked');
+	steamcardexchange_inv = $("#steamcardexchange_inv").prop('checked');
 
 	chrome.storage.sync.set({
 		'highlight_owned_color': highlight_owned_color,
@@ -230,7 +231,8 @@ function save_options() {
 		'profile_permalink': profile_permalink,
 		'show_profile_link_images': show_profile_link_images,
 		
-		'steamcardexchange': steamcardexchange
+		'steamcardexchange': steamcardexchange,
+		'steamcardexchange_inv': steamcardexchange_inv
 	});
 	$("#saved").stop(true,true).fadeIn().delay(600).fadeOut();
 }
@@ -455,6 +457,7 @@ function load_options() {
 		if (settings.api_key == false||settings.api_key==""||settings.api_key===undefined){ settings.profile_api_info = false; chrome.storage.sync.set({'profile_api_info': settings.profile_api_info});}
 		if (settings.profile_permalink === undefined) { settings.profile_permalink = true; chrome.storage.sync.set({'profile_permalink': settings.profile_permalink}); }
 		if (settings.steamcardexchange == undefined) { settings.steamcardexchange = true; chrome.storage.sync.set({'steamcardexchange': settings.steamcardexchange}); }
+		if (settings.steamcardexchange_inv == undefined) { settings.steamcardexchange_inv = false; chrome.storage.sync.set({'steamcardexchange_inv': settings.steamcardexchange_inv}); }
 		
 		// Load Store Options
 		$("#highlight_owned_color").val(settings.highlight_owned_color);
@@ -554,6 +557,7 @@ function load_options() {
 		$("#api_key").val(settings.api_key)
 		$("#profile_permalink").prop('checked', settings.profile_permalink);
 		$("#steamcardexchange").prop('checked', settings.steamcardexchange);
+		$("#steamcardexchange_inv").prop('checked', settings.steamcardexchange_inv);
 		
 		if(!changelog_loaded) {		
 			jQuery.get('changelog.txt', function(data) {
@@ -664,6 +668,7 @@ function load_translation() {
 			$("#spamcommentregex_text").text(localized_strings[settings.language].options.spamcommentregex);
 			$("#show_spamcommentregex").text(localized_strings[settings.language].options.customizespamcommentregex);
 			$("#steamcardexchange_text").text(localized_strings[settings.language].options.steamcardexchange);
+			$("#steamcardexchange_inv_text").text(localized_strings[settings.language].options.steamcardexchange_inv);
 			$("#wlbuttoncommunityapp_text").text(localized_strings[settings.language].options.wlbuttoncommunityapp);
 
 			$("#highlight_owned_default").text(localized_strings[settings.language].theworddefault);

--- a/options.html
+++ b/options.html
@@ -347,6 +347,7 @@
 					<li>
 						<input type="checkbox" id="steamcardexchange"><label for="steamcardexchange" id="steamcardexchange_text">Show SteamCardExchange links on badges</label>
 						<a href="http://enhancedsteam.com/featuredetail.php?id=19" class="help"></a>
+						<input type="checkbox" id="steamcardexchange_inv"><label for="steamcardexchange_inv" id="steamcardexchange_inv_text">Link to bot inventory instead of showcase</label>
 					</li>
 					<li>
 						<input type="checkbox" id="wlbuttoncommunityapp"><label for="wlbuttoncommunityapp" id="wlbuttoncommunityapp_text">Show "Add to Wishlist" button on community app hubs</label>


### PR DESCRIPTION
New option (default false) to link directly to the inventory of the Steam Card Exchange bot instead of the showcase.
