### PR TITLE
Updated the market transaction calculations

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -3249,10 +3249,6 @@ function add_market_total() {
 
                         var matches = price_regex.exec(ptext);
 
-                        if (matches === null)
-                            debugger;
-
-
                         var isGain = $p.children('.market_listing_gainorloss').text().trim() === "+",
                             currency_symbol = matches[1].trim(),
                             currency_code = currency_symbol_to_type(currency_symbol).trim(),


### PR DESCRIPTION
The market transaction calculations now calculate currencies, albeit with today's exchange rate, which are not the user's local currency. The values are also cached to avoid recalculating when there's been no changes in the user's market transactions. 

This addresses #625.
