### PR TITLE
Update to Steam Gifts link syntax

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -2101,7 +2101,7 @@ function add_community_profile_links() {
 			htmlstr += '</span></a></div>';
 		}
 		if (settings.profile_steamgifts) {
-			htmlstr += '<div class="profile_count_link"><a href="http://www.steamgifts.com/user/id/' + steamID + '" target="_blank"><span class="count_link_label">SteamGifts</span>&nbsp;<span class="profile_count_link_total">';
+			htmlstr += '<div class="profile_count_link"><a href="http://www.steamgifts.com/go/user/' + steamID + '" target="_blank"><span class="count_link_label">SteamGifts</span>&nbsp;<span class="profile_count_link_total">';
 			if (settings.show_profile_link_images!="false"){htmlstr += '<img src="' + chrome.extension.getURL('img/ico/steamgifts'+icon_color+'.png') + '" class="profile_link_icon">';}
 			else {htmlstr += '&nbsp;'}
 			htmlstr += '</span></a></div>';


### PR DESCRIPTION
The currently used link syntax for Steam Gifts links on profiles [may be subject to change in the future](http://www.steamgifts.com/go/comment/j5vhyqg), so this pull request updates the format to the new syntax.