### PR TITLE
Bug Fix (Issue #680)

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -5510,7 +5510,7 @@ function add_app_page_wishlist_changes(appid) {
 				// get community session variable (this is different from the store session)
 				get_http("http://steamcommunity.com/my/wishlist", function(txt) {
 					var session = txt.match(/sessionid" value="(.+)"/)[1];
-					var user = $("#account_pulldown").text();
+					var user = $(".username").text();
 
 					$.ajax({
 						type:"POST",


### PR DESCRIPTION
Fixes bug where users could not remove items from their wishlist from
the store page.
Removal request must use user's profile name, not their account name.