### PR TITLE
Fixed incorrect "games with drops remaining" count

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -6542,7 +6542,7 @@ function add_total_drops_count() {
 		function add_total_drops_count_calculations(games) {
 			$(games).each(function(i, obj) {
 				var obj_count = obj.find(".progress_info_bold")[0].innerHTML.match(/\d+/);
-				if (obj_count) {
+				if (obj_count && obj_count[0]!='0') {
 					drops_count += parseInt(obj_count[0]);
 					drops_games = drops_games + 1;
 				}


### PR DESCRIPTION
In Russian locale games are marked as "Выпадет карточек: 0" ("Сard drops: 0"), so they pass the regexp (unlike English-locale "No card drops remaining") and are being accounted as games with drops.