### PR TITLE
added vote preview on Greenlight browsing pages

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -759,3 +759,27 @@ input[type=checkbox].es_dlc_selection:checked + label {
 	color: #61686d;
 	font-weight: normal;
 }
+
+.gh_fade div {
+	opacity: 0.2;
+}
+.gh_vote_up:before, .gh_vote_down:before, .gh_vote_later:before {
+	position: absolute;
+	top: 0px;
+	left: 0px;
+	padding: 5px;
+	background: rgba(0, 0, 0, 0.6);
+}
+.gh_fade:before {
+	background: none;
+}
+.gh_vote_up:before {
+	content: url('//steamcommunity-a.akamaihd.net/public/images/sharedfiles/ig/nav_vote_yes.png');
+}
+.gh_vote_down:before {
+	content: url('//steamcommunity-a.akamaihd.net/public/images/sharedfiles/ig/nav_vote_no.png');
+}
+.gh_vote_later:before {
+	content: url('//steamcommunity-a.akamaihd.net/public/images/sharedfiles/ig/nav_remind_later.png');
+}
+

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -2744,6 +2744,35 @@ function hide_greenlight_banner() {
 	});
 }
 
+function preview_greenlight_votes() {
+	storage.get(function(settings) {
+		if (settings.fadevotedgreenlightitems === undefined) { settings.fadevotedgreenlightitems = false; storage.set({'fadevotedgreenlightitems': settings.fadevotedgreenlightitems}); }
+		if (settings.previewgreenlightvotes === undefined) { settings.previewgreenlightvotes = false; storage.set({'previewgreenlightvotes': settings.previewgreenlightvotes}); }
+		if (settings.fadevotedgreenlightitems || settings.previewgreenlightvotes) {
+			$("a").each(function() {
+				if (this.href.match("^[^:]+://steamcommunity\\.com/sharedfiles/filedetails/\\?id=")) {
+					var parent = $(this).parent();
+					if (parent.hasClass("gh_checked") || !parent.hasClass("workshopItem")) return;
+					$.ajax({
+						url: this.href,
+						context: parent
+					}).done(function (data) {
+						match = data.match(/<a[^>]*toggled[^>]*id="Vote(Up|Down|Later)Btn"[^>]*>/);
+						if (match) {
+							if (settings.fadevotedgreenlightitems) {
+								this.addClass("gh_fade");
+							}
+							if (settings.previewgreenlightvotes) {
+								this.addClass("gh_vote_" + match[1].toLowerCase());
+							}
+						}
+					});
+				}
+			});
+		}
+	});
+}
+
 function hide_spam_comments() {
 	storage.get(function(settings) {
 		if (settings.hidespamcomments === undefined) { settings.hidespamcomments = false; storage.set({'hidespamcomments': settings.hidespamcomments}); }
@@ -7172,9 +7201,19 @@ $(document).ready(function(){
 							add_profile_style();
 							break;
 
-						case /^\/(?:sharedfiles|workshop)\/.*/.test(path):
+						case /^\/sharedfiles\/.*/.test(path):
 							hide_greenlight_banner();
 							hide_spam_comments();
+							break;
+
+						case /^\/workshop\/.*/.test(path):
+							hide_greenlight_banner();
+							hide_spam_comments();
+							preview_greenlight_votes();
+							break;
+
+						case /^\/greenlight\/.*/.test(path):
+							preview_greenlight_votes();
 							break;
 
 						case /^\/market\/.*/.test(path):

--- a/js/options.js
+++ b/js/options.js
@@ -115,6 +115,8 @@ function save_options() {
 	showallachievements = $("#showallachievements").prop('checked');
 	showcomparelinks = $("#showcomparelinks").prop('checked');
 	showgreenlightbanner = $("#showgreenlightbanner").prop('checked');
+	fadevotedgreenlightitems = $("#fadevotedgreenlightitems").prop('checked');
+	previewgreenlightvotes = $("#previewgreenlightvotes").prop('checked');
 	hideactivelistings = $("#hideactivelistings").prop('checked');
 	hidespamcomments = $("#hidespamcomments").prop('checked');
 	spamcommentregex = $("#spamcommentregex").val().trim();
@@ -208,6 +210,8 @@ function save_options() {
 		'showallachievements': showallachievements,
 		'showcomparelinks': showcomparelinks,
 		'showgreenlightbanner': showgreenlightbanner,
+		'fadevotedgreenlightitems': fadevotedgreenlightitems,
+		'previewgreenlightvotes': previewgreenlightvotes,
 		'hideactivelistings': hideactivelistings,
 		'hidespamcomments': hidespamcomments,
 		'spamcommentregex': spamcommentregex,
@@ -409,6 +413,8 @@ function load_options() {
 		if (settings.showallachievements === undefined) { settings.showallachievements = false; chrome.storage.sync.set({'showallachievements': settings.showallachievements}); }
 		if (settings.showcomparelinks === undefined) { settings.showcomparelinks = false; chrome.storage.sync.set({'showcomparelinks': settings.showcomparelinks}); }
 		if (settings.showgreenlightbanner === undefined) { settings.showgreenlightbanner = false; chrome.storage.sync.set({'showgreenlightbanner': settings.showgreenlightbanner}); }
+		if (settings.fadevotedgreenlightitems === undefined) { settings.fadevotedgreenlightitems = false; chrome.storage.sync.set({'fadevotedgreenlightitems': settings.fadevotedgreenlightitems}); }
+		if (settings.previewgreenlightvotes === undefined) { settings.previewgreenlightvotes = false; chrome.storage.sync.set({'previewgreenlightvotes': settings.previewgreenlightvotes}); }
 		if (settings.hideactivelistings === undefined) { settings.hideactivelistings = false; chrome.storage.sync.set({'hideactivelistings': settings.hideactivelistings}); }
 		if (settings.hidespamcomments === undefined) { settings.hidespamcomments = false; chrome.storage.sync.set({'hidespamcomments': settings.hidespamcomments}); }
 		if (settings.spamcommentregex === undefined) { settings.spamcommentregex = "[\\u2500-\\u25FF]"; chrome.storage.sync.set({'spamcommentregex': settings.spamcommentregex}); }
@@ -503,6 +509,8 @@ function load_options() {
 		$("#showallachievements").prop('checked', settings.showallachievements);
 		$("#showcomparelinks").prop('checked', settings.showcomparelinks);
 		$("#showgreenlightbanner").prop('checked', settings.showgreenlightbanner);
+		$("#fadevotedgreenlightitems").prop('checked', settings.fadevotedgreenlightitems);
+		$("#previewgreenlightvotes").prop('checked', settings.previewgreenlightvotes);
 		$("#hideactivelistings").prop('checked', settings.hideactivelistings);
 		$("#hidespamcomments").prop('checked', settings.hidespamcomments);
 		$("#spamcommentregex").val(settings.spamcommentregex);

--- a/localization/de/strings.json
+++ b/localization/de/strings.json
@@ -307,6 +307,8 @@
     "hide_install":"\"Steam installieren\" Schaltfläche verbergen",
     "lowestprice_coupon":"Gutscheine in den Preisvergleich mit einbeziehen",
     "greenlight_banner":"Greenlight Banner ersetzen",
+    "greenlight_fade_voted":"Abgestimmte Greenlight-Spiele ausblenden",
+    "greenlight_vote_preview":"Vorschau für Greenlight-Stimme",
     "general":"Allgemeines",
     "show_languagewarning":"Warnung anzeigen wenn eine andere Sprache dargestellt wird als",
     "wishlist":"Spiele auf meiner Wunschliste"

--- a/options.html
+++ b/options.html
@@ -318,6 +318,12 @@
 						<a href="http://enhancedsteam.com/featuredetail.php?id=14" class="help"></a>
 					</li>
 					<li>
+						<input type="checkbox" id="fadevotedgreenlightitems"><label for="fadevotedgreenlightitems" id="greenlight_fade_voted_text">Fade voted Greenlight items</label>
+					</li>
+					<li>
+						<input type="checkbox" id="previewgreenlightvotes"><label for="previewgreenlightvotes" id="greenlight_vote_preview_text">Preview Greenlight votes</label>
+					</li>
+					<li>
 						<input type="checkbox" id="hideactivelistings"><label for="hideactivelistings" id="hideactivelistings_text">Hide all active listings on Market homepage by default</label>
 					</li>
 					<li>


### PR DESCRIPTION
Added vote preview and fading of voted items on Greenlight browsing pages, added one option for each (both off by default), including german translation. Also converted it to jQuery instead of plain JS and improved it a little (simpler code and better performance compared to my original).

I'm not really happy with the option names, but I couldn't think of any better. Maybe someone else can.

Extensively tested, no known problems (except for not being able to use any API).