### PR TITLE
FIX: Price with spaces getting parsed incorrectly when applying a coupon

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -1850,6 +1850,8 @@ function display_coupon_message(appid) {
 				actual_price_container = actual_price_container.replace(",", "");
 			}
 
+			actual_price_container = actual_price_container.replace(/\s/g, "");
+
 			var original_price = parseFloat(actual_price_container.match(/([0-9]+(?:(?:\,|\.)[0-9]+)?)/)[1]);
 			var discounted_price = (original_price - (original_price * getValue(appid + "coupon_discount") / 100).toFixed(2)).toFixed(2);
 


### PR DESCRIPTION
When spaces are used as the thousand separator, any item for which a coupon is available will have its original price incorrectly parsed and ends up being replaced with an incorrect discounted price.

![image](https://cloud.githubusercontent.com/assets/927915/9188803/d1b66932-400a-11e5-99a6-d4786fdbe7ad.png)

In case it's not obvious, the last three digits of both the original price and the discounted price were accidentally truncated when applying the coupon.