### PR TITLE
ADD: An option to show a Chat link in the header

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -7252,6 +7252,15 @@ function launch_random_button() {
 	});
 }
 
+function add_chat_link() {
+	storage.get(function(settings) {
+		if (settings.showchatlink === undefined) { settings.showchatlink = false; storage.set({'showchatlink': settings.showchatlink}); }
+		if (settings.showchatlink) {
+			$(".menuitem.username").after('<a class="menuitem es_chat_item" style="cursor: pointer" onclick="window.open(\'https://steamcommunity.com/chat/\', \'SteamWebChat\', \'height=790,width=1015,resize=yes,scrollbars=yes\')"> CHAT	</a>');
+		}
+	});
+}
+
 $(document).ready(function(){
 	localization_promise.done(function(){
 		signed_in_promise.done(function(){
@@ -7272,6 +7281,7 @@ $(document).ready(function(){
 				replace_account_name();
 				add_birthday_celebration();
 				launch_random_button();
+				add_chat_link();
 			}			
 
 			// Attach event to the logout button

--- a/js/options.js
+++ b/js/options.js
@@ -123,6 +123,7 @@ function save_options() {
 	hidespamcomments = $("#hidespamcomments").prop('checked');
 	spamcommentregex = $("#spamcommentregex").val().trim();
 	wlbuttoncommunityapp = $("#wlbuttoncommunityapp").prop('checked');
+	showchatlink = $("#showchatlink").prop('checked');
 	show1clickgoo = $("#show1clickgoo").prop('checked');
 
 	// Profile Link Options
@@ -220,6 +221,7 @@ function save_options() {
 		'hidespamcomments': hidespamcomments,
 		'spamcommentregex': spamcommentregex,
 		'wlbuttoncommunityapp': wlbuttoncommunityapp,
+		'showchatlink': showchatlink,
 		'show1clickgoo': show1clickgoo,
 
 		'profile_steamgifts': profile_steamgifts,
@@ -425,6 +427,7 @@ function load_options() {
 		if (settings.hidespamcomments === undefined) { settings.hidespamcomments = false; chrome.storage.sync.set({'hidespamcomments': settings.hidespamcomments}); }
 		if (settings.spamcommentregex === undefined) { settings.spamcommentregex = "[\\u2500-\\u25FF]"; chrome.storage.sync.set({'spamcommentregex': settings.spamcommentregex}); }
 		if (settings.wlbuttoncommunityapp === undefined) { settings.wlbuttoncommunityapp = true; chrome.storage.sync.set({'wlbuttoncommunityapp': settings.wlbuttoncommunityapp}); }
+		if (settings.showchatlink === undefined) { settings.showchatlink = false; chrome.storage.sync.set({'showchatlink': settings.showchatlink}); }
 		if (settings.show1clickgoo === undefined) { settings.show1clickgoo = true; chrome.storage.sync.set({'show1clickgoo': settings.show1clickgoo}); }
 		if (settings.show_profile_link_images === undefined) { settings.show_profile_link_images = "gray"; chrome.storage.sync.set({'show_profile_link_images': settings.show_profile_link_images}); }
 		if (settings.profile_steamgifts === undefined) { settings.profile_steamgifts = true; chrome.storage.sync.set({'profile_steamgifts': settings.profile_steamgifts}); }
@@ -523,6 +526,7 @@ function load_options() {
 		$("#hidespamcomments").prop('checked', settings.hidespamcomments);
 		$("#spamcommentregex").val(settings.spamcommentregex);
 		$("#wlbuttoncommunityapp").prop('checked', settings.wlbuttoncommunityapp);
+		$("#showchatlink").prop('checked', settings.showchatlink);
 		$("#show1clickgoo").prop('checked', settings.show1clickgoo);
 		$("#profile_link_images_dropdown").val(settings.show_profile_link_images);
 
@@ -691,6 +695,7 @@ function load_translation() {
 			$("#show_spamcommentregex").text(localized_strings.options.customizespamcommentregex);
 			$("#steamcardexchange_text").text(localized_strings.options.steamcardexchange);
 			$("#wlbuttoncommunityapp_text").text(localized_strings.options.wlbuttoncommunityapp);
+			$("#showchatlink_text").text(localized_strings[settings.language].options.showchatlink);
 			$("#show1clickgoo_text").text(localized_strings.options.show1clickgoo);
 
 			$("#highlight_owned_default").text(localized_strings.theworddefault);

--- a/options.html
+++ b/options.html
@@ -381,7 +381,9 @@
 					<li>
 						<input type="checkbox" id="wlbuttoncommunityapp"><label for="wlbuttoncommunityapp" id="wlbuttoncommunityapp_text">Show "Add to Wishlist" button on community app hubs</label>
 					</li>
-									
+					<li>
+						<input type="checkbox" id="showchatlink"><label for="showchatlink" id="showchatlink_text">Show a Chat link in the header</label>
+					</li>
 			</ul>
 
 		</div>


### PR DESCRIPTION
![](https://cloud.githubusercontent.com/assets/3451904/5581961/5568c968-9062-11e4-8b47-f61d6b6de936.png)

~~                                                                                                                                      ~~

Idea from #675. Resubmitted in fewer commits and to avoid merge conflicts (old PR: #676).

~~                                                                                                                                      ~~

New string: **options.showchatlink**

EN translation:
Show a Chat link in the header