### PR TITLE
Fix: enable Total Spent feature for all apropriate URLs

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -3498,7 +3498,7 @@ function account_total_spent() {
 				});
 
 				function start_total() {
-					if (window.location.pathname == "/account/store_transactions/") {
+					if (window.location.pathname.match("/account(/store_transactions)?/?$")) {
 						$(".account_setting_block:first .account_setting_sub_block:nth-child(2)").prepend("<div id='es_total' class='es_loading' style='text-align: center;'><span>" + localized_strings.loading + "</span></div>");
 
 						var game_total = 0,


### PR DESCRIPTION
Total Spent feature only appears on `.../account/store_transactions/`, but should also appear on `.../account/` (and with or without trailing slash), since they point to the same page.