### PR TITLE
FIX: #778

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -851,3 +851,7 @@ input[type=checkbox].es_dlc_selection:checked + label {
 	min-width: 120px;
 	text-align: center;
 }
+
+.search_suggest .match.focus {
+	background: #212d3d !important;
+}


### PR DESCRIPTION
This restores the original selection background color for entries that are both selected and highlighted, since in my opinion the selection takes precedence over the highlighting.