### PR TITLE
Add option on friends pages to sort friends by last online

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -416,6 +416,30 @@ input[type=checkbox].es_dlc_selection:checked + label {
 	cursor: pointer;
 }
 
+#friends_sort_options {
+	text-align: right;
+	margin-bottom: 12px;
+	margin-right: 52px;
+	font-size: 14px;
+	color: #939393;
+}
+
+.manage_friends_header #friends_sort_options {
+	float: right;
+	margin-bottom: 0;
+	margin-right: 35px;
+}
+
+#friends_sort_options span {
+	margin-left: 8px;
+	color: #B0AEAC;
+}
+
+.es_friends_sort_link {
+	text-decoration: underline;
+	cursor: pointer;
+}
+
 .browse_tag_game_cap img {
 	margin-left: 8px;
 }

--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -181,6 +181,7 @@
     "historical_low": "Historical Lowest Price",
     "games_with_booster": "__boostergames__ games eligible for booster packs",
     "sort_by": "Sort by:",
+    "lastonline": "Last Online",
     "edit_price": "Edit Price",
     "relist": "Relist",
     "relist_an_item": "Relist an item",


### PR DESCRIPTION
Sort order will be remembered until it is changed again. Works on all friends lists, not only the own one.

Looks just like the option for sorting achievements by date unlocked, but is implemented completely different, so it doesn't interfere with the Manage Friends List functions.