### PR TITLE
Improve 'Buy <bundle name>' header translation

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -2026,8 +2026,8 @@ function show_pricing_history(appid, type) {
 										} else {
 											continue;
 										}
-										if (data["bundles"]["live"][i]["page"]) { purchase = '<div class="game_area_purchase_game"><div class="game_area_purchase_platform"></div><h1>' + localized_strings.buy + ' ' + data["bundles"]["live"][i]["page"] + ' ' + data["bundles"]["live"][i]["title"] + '</h1>'; } 
-										else { purchase = '<div class="game_area_purchase_game_wrapper"><div class="game_area_purchase_game"><div class="game_area_purchase_platform"></div><h1>' + localized_strings.buy + ' ' + data["bundles"]["live"][i]["title"] + '</h1>'; }
+										if (data["bundles"]["live"][i]["page"]) { purchase = '<div class="game_area_purchase_game"><div class="game_area_purchase_platform"></div><h1>' + localized_strings.buy_package.replace(/__package__/, data["bundles"]["live"][i]["page"] + ' ' + data["bundles"]["live"][i]["title"]) + '</h1>'; }
+										else { purchase = '<div class="game_area_purchase_game_wrapper"><div class="game_area_purchase_game"><div class="game_area_purchase_platform"></div><h1>' + localized_strings.buy_package.replace(/__package__/, data["bundles"]["live"][i]["title"]) + '</h1>'; }
 										if (enddate) purchase += '<p class="game_purchase_discount_countdown">' + localized_strings.bundle.offer_ends + ' ' + enddate + '</p>';
 										purchase += '<p class="package_contents">';
 										var tier_num = 1,

--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -155,6 +155,7 @@
     "saved": "Saved",
     "add_unowned_dlc_to_cart": "Add unowned DLC to cart",
     "buy": "Buy",
+    "buy_package": "Buy __package__",
     "more_information": "More Information",
     "games_discount": "Games With Discounts",
     "region_unavailable": "Not available in this region",


### PR DESCRIPTION
Word order can be different in other languages.