### PR TITLE
FIX: #811 (Market relist only supports period as decimal separator)

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -855,3 +855,7 @@ input[type=checkbox].es_dlc_selection:checked + label {
 .search_suggest .match.focus {
 	background: #212d3d !important;
 }
+
+#es_sell #market_sell_buyercurrency_input:invalid {
+	border-color: #c00000;
+}

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -4013,10 +4013,12 @@ function add_relist_button() {
 					$("#es_relist_confirm").show();
 					$("#es_sell").show();
 				}	
+				var pricepattern = "^[^\\d,.]*\s*([1-9]\\d{0,2}?(?:([,. ]?)\\d{3}(?:\\2\\d{3})*)?|0)(?:([,.])(\\d{1,2}))?\s*[^\\d,.]*$"
 				if ($(".market_sell_dialog_input_group").length == 0) {
 					$("#es_sell").load("//steamcommunity.com/my/inventory/ .market_sell_dialog_input_group:last", function() { 
 						$(".market_sell_dialog_input_group").css("float", "right");
 						$("#market_sell_buyercurrency_input").focus();
+						$("#market_sell_buyercurrency_input")[0].pattern = pricepattern;
 						$("#es_relist_confirm").removeClass("btn_disabled");
 					});
 				} else {
@@ -4027,8 +4029,12 @@ function add_relist_button() {
 				}
 				
 				$("#es_relist_confirm").on("click", function() {
-					var sell_price = parseFloat($("#market_sell_buyercurrency_input").val()) * 100;
-					if (isNaN(sell_price)) return;
+					var pricematch = $("#market_sell_buyercurrency_input").val().match(pricepattern);
+					if (pricematch) {
+						var sell_price = parseFloat((pricematch[1]).replace(/[^\d]/, "") + "." + (pricematch[4] || 0)) * 100;
+					} else {
+						return;
+					}
 
 					$("#es_relist_confirm").hide();
 					$(".market_sell_dialog_input_group").hide();


### PR DESCRIPTION
Validates price input via regular expression, instead of only accepting JS floats.
Allows comma and period as decimal separator and comma, period and space as thousands separator, as well as currency symbols before and after the number.
Invalid input is indicated by red border.