### PR TITLE
FIX #827 (Bundle price misaligned)

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -230,7 +230,6 @@ img.platform_small, .platform_img {
 .es_each {
 	color: #626366;
 	font-size: 11px;
-	float:right;
 	margin-top:-2px;
 }
 .es_each_price {


### PR DESCRIPTION
CSS class "es_each" is used for bundle info and multi-pack split, I checked both cases with my change.