### PR TITLE
Fixes CLP currency detection

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -295,7 +295,7 @@ function currency_type_to_number (currency_type) {
 }
 
 function currency_symbol_from_string (string_with_symbol) {
-	var re = /(?:R\$|S\$|\$|RM|kr|Rp|€|¥|£|฿|pуб|P|₫|₩|TL|₴|Mex\$|CDN\$|A\$|HK\$|NT\$|₹|SR|R |DH|CHF|CLP$|S\/\.|COL\$|NZ\$)/;
+	var re = /(?:R\$|S\$|\$|RM|kr|Rp|€|¥|£|฿|pуб|P|₫|₩|TL|₴|Mex\$|CDN\$|A\$|HK\$|NT\$|₹|SR|R |DH|CHF|CLP\$|S\/\.|COL\$|NZ\$)/;
 	var match = string_with_symbol.match(re);
 	return match ? match[0] : '';
 }


### PR DESCRIPTION
Unescaped "$" in the regex from ``currency_symbol_from_string`` function caused CLP currency being detected as PHP, as seen in #872.