### PR TITLE
Fixes increased row height on listings page

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -3914,7 +3914,7 @@ function add_lowest_market_price() {
 	if ($("#tabContentsMyListings .market_listing_row").length <= 11 ) {
 		add_lowest_market_price_data();
 	} else {
-		$(".market_listing_es_lowest").html("<a class='es_market_lowest_button'><img src='//store.akamai.steamstatic.com/public/images/v6/ico/ico_cloud.png' height=24 style='margin-top: 13px;'></a>");
+		$(".market_listing_es_lowest").html("<a class='es_market_lowest_button'><img src='//store.akamai.steamstatic.com/public/images/v6/ico/ico_cloud.png' height=24 style='vertical-align: middle;'></a>");
 		$("#es_selling_total .market_listing_es_lowest").html("&nbsp;");
 	}
 	$(".es_market_lowest_button").click(function() {


### PR DESCRIPTION
Using "margin-top: 13px;" on the cloud image to align it vertically increases the height of the main row, multiply this by a few hundred times (based on how many listing you have) and the overall page height is increased quite a bit. To fix it use "vertical-align: middle;" instead.
See https://imgur.com/Sj4ofhY for comparison.