### PR TITLE
FIX: Total spent not showing or incorrect currency

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -920,11 +920,27 @@ input[type=checkbox].es_dlc_selection:checked + label {
     height: 8px;
     background-color: #aeaeae;
 }
+
 #es_customize_btn {
 	visibility: visible;
 }
-.home_page_content #es_customize_btn {
-	margin: -12px 0 0 0;
+.home_viewsettings_popup {
+	right: 18px;
+	display: none;
+	z-index: 12;
+}
+.home_page_body_ctn.has_takeover #es_customize_btn {
+	margin: -24px 0 0 0;
+}
+.home_page_body_ctn:not(.has_takeover) #es_customize_btn {
+	position: absolute;
+	right: 15px;
+}
+.home_page_body_ctn:not(.has_takeover) .home_cluster_ctn {
+	margin-top: 40px
+}
+.home_page_body_ctn:not(.has_takeover) .home_viewsettings_popup {
+	right: 2px;
 }
 
 /***************************************

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -3590,7 +3590,7 @@ function add_steam_client_link(appid) {
 	storage.get(function(settings) {
 		if (settings.showclient === undefined) { settings.showclient = true; storage.set({'showclient': settings.showclient}); }
 		if (settings.showclient) {
-			$('#ReportAppBtn').parent().prepend('<a class="btnv6_blue_hoverfade btn_medium steam_client_btn" href="steam://store/' + appid + '" style="display: block; margin-bottom: 6px;"><span><i class="ico16" style="background-image:url(http://store.steampowered.com/favicon.ico)"></i>&nbsp;&nbsp; ' + localized_strings.viewinclient + '</span></a>');
+			$('#ReportAppBtn').parent().prepend('<a class="btnv6_blue_hoverfade btn_medium steam_client_btn" href="steam://url/StoreAppPage/' + appid + '" style="display: block; margin-bottom: 6px;"><span><i class="ico16" style="background-image:url(http://store.steampowered.com/favicon.ico)"></i>&nbsp;&nbsp; ' + localized_strings.viewinclient + '</span></a>');
 		}
 	});
 }

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -5800,7 +5800,7 @@ function customize_home_page() {
 		if (settings.show_homepage_under_ten === undefined) { settings.show_homepage_under_ten = true; storage.set({'show_show_homepage_under_ten': settings.show_homepage_under_ten}); }
 		if (settings.show_homepage_sidebar === undefined) { settings.show_homepage_sidebar = true; storage.set({'show_homepage_sidebar': settings.show_homepage_sidebar}); }
 
-		var html = "<div class='home_viewsettings_popup' style='display: none; z-index: 12; right: 18px;'><div class='home_viewsettings_instructions' style='font-size: 12px;'>" + localized_strings.apppage_sections + "</div>"
+		var html = "<div class='home_viewsettings_popup'><div class='home_viewsettings_instructions' style='font-size: 12px;'>" + localized_strings.apppage_sections + "</div>"
 
 		// Carousel
 		if ($("#home_main_cluster").length > 0) {

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -5012,7 +5012,7 @@ function add_astats_link(appid) {
 }
 
 function add_achievement_completion_bar(appid) {
-	$(".myactivity_block").find(".details_block").after("<link href='http://steamcommunity-a.akamaihd.net/public/css/skin_1/playerstats_generic.css' rel='stylesheet' type='text/css'><div id='es_ach_stats' style='margin-bottom: 9px; margin-top: -16px; float: right;'></div>");
+	$(".myactivity_block").find(".details_block:first").after("<link href='http://steamcommunity-a.akamaihd.net/public/css/skin_1/playerstats_generic.css' rel='stylesheet' type='text/css'><div id='es_ach_stats' style='margin-bottom: 9px; margin-top: -16px; float: right;'></div>");
 	$("#es_ach_stats").load("//steamcommunity.com/my/stats/" + appid + "/ #topSummaryAchievements", function(response, status, xhr) {				
 		if (response.match(/achieveBarFull\.gif/)) {
 			var BarFull = $("#es_ach_stats").html().match(/achieveBarFull\.gif" width="([0-9]|[1-9][0-9]|[1-9][0-9][0-9])"/)[1];
@@ -6590,7 +6590,7 @@ function add_app_page_wishlist(appid) {
 function add_app_page_wishlist_changes(appid) {
 	if (is_signed_in) {
 		if ($("#add_to_wishlist_area").length == 0 && $(".game_area_already_owned").length == 0) {
-			$(".queue_actions_ctn").find("img[src='http://store.akamai.steamstatic.com/public/images/v6/ico/ico_selected.png']").parent().parent().wrap("<div id='add_to_wishlist_area_success' style='display: inline-block;'></div>");
+			$(".queue_actions_ctn").find("a.queue_btn_active:first").wrap("<div id='add_to_wishlist_area_success' style='display: inline-block;'></div>");
 			$(".queue_actions_ctn").prepend("<div id='add_to_wishlist_area' style='display: none;'><a class='btnv6_blue_hoverfade btn_medium' href='javascript:AddToWishlist( " + appid + ", \"add_to_wishlist_area\", \"add_to_wishlist_area_success\", \"add_to_wishlist_area_fail\", \"1_5_9__407\" );'><span>" + localized_strings.add_to_wishlist + "</span></a></div>");
 			$(".queue_actions_ctn").prepend("<div id='add_to_wishlist_area_fail' style='display: none;'></div>");
 		}


### PR DESCRIPTION
- While viewing Store Transactions "Total spent" might not show or show
with USD as currency due to Storage API's per-origin policy  and to
mixed-content policy(requesting HTTP from a HTTPS page).
- While colecting data warnings were shown due to synchronous ajax
requests
- If the element selector for the price container could not be found an
invalid currency would end up being inserted in storage

![aaa](https://cloud.githubusercontent.com/assets/3322834/13769331/0600ea22-ea7f-11e5-8487-15a3ddcdc2c2.png)