### PR TITLE
Readme now redirects to download page instead of just chrome download

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Installation
 ------------
 
 ##### Automatic
-Click [here](http://www.enhancedsteam.com/download-chrome.php) and follow the instructions
+Click [here](http://www.enhancedsteam.com/download.php) and follow the instructions
 
 _(Not Working? Try [here](https://chrome.google.com/webstore/detail/enhanced-steam/okadibdjfemgnhjiembecghcbfknbfhg))_
 


### PR DESCRIPTION
I figured it made more sense to just link to the downloads page instead of the Chrome download
