### PR TITLE
Move the button up only if there is no featured app

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -920,11 +920,27 @@ input[type=checkbox].es_dlc_selection:checked + label {
     height: 8px;
     background-color: #aeaeae;
 }
+
 #es_customize_btn {
 	visibility: visible;
 }
-.home_page_content #es_customize_btn {
-	margin: -12px 0 0 0;
+.home_viewsettings_popup {
+	right: 18px;
+	display: none;
+	z-index: 12;
+}
+.home_page_body_ctn.has_takeover #es_customize_btn {
+	margin: -24px 0 0 0;
+}
+.home_page_body_ctn:not(.has_takeover) #es_customize_btn {
+	position: absolute;
+	right: 15px;
+}
+.home_page_body_ctn:not(.has_takeover) .home_cluster_ctn {
+	margin-top: 40px
+}
+.home_page_body_ctn:not(.has_takeover) .home_viewsettings_popup {
+	right: 2px;
 }
 
 /***************************************

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -5782,7 +5782,7 @@ function customize_home_page() {
 		if (settings.show_homepage_under_ten === undefined) { settings.show_homepage_under_ten = true; storage.set({'show_show_homepage_under_ten': settings.show_homepage_under_ten}); }
 		if (settings.show_homepage_sidebar === undefined) { settings.show_homepage_sidebar = true; storage.set({'show_homepage_sidebar': settings.show_homepage_sidebar}); }
 
-		var html = "<div class='home_viewsettings_popup' style='display: none; z-index: 12; right: 18px;'><div class='home_viewsettings_instructions' style='font-size: 12px;'>" + localized_strings.apppage_sections + "</div>"
+		var html = "<div class='home_viewsettings_popup'><div class='home_viewsettings_instructions' style='font-size: 12px;'>" + localized_strings.apppage_sections + "</div>"
 
 		// Carousel
 		if ($("#home_main_cluster").length > 0) {


### PR DESCRIPTION
Didn't take into consideration the button might overlap the menu when
there is no featured app on the main page. It should be fine now, the
page won't shift/move down anymore when the "Customize" button is
inserted.