### PR TITLE
Fixed CNY has been detected as JPY

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -213,9 +213,15 @@ function formatCurrency(number, type) {
 	return formatted;
 }
 
+function get_currency_from_DOM() {
+	var currency_node = document.querySelector('meta[itemprop="priceCurrency"]');
+	if (currency_node && currency_node.hasAttribute("content")) return currency_node.getAttribute("content");
+	return null;
+}
+
 function parse_currency(str) {
 	var currency_symbol = currency_symbol_from_string(str);
-	var currency_type = currency_symbol_to_type(currency_symbol);
+	var currency_type = get_currency_from_DOM() || currency_symbol_to_type(currency_symbol);
 	if (user_currency && currency_format_info[user_currency].symbolFormat == currency_format_info[currency_type].symbolFormat) currency_type = user_currency;
 	var currency_number = currency_type_to_number(currency_type);
 	var info = currency_format_info[currency_type];
@@ -291,6 +297,7 @@ function currency_type_to_number (currency_type) {
 		"CAD": 20,
 		"AUD": 21,
 		"NZD": 22,
+		"CNY": 23,
 		"INR": 24,
 		"CLP": 25,
 		"PEN": 26,


### PR DESCRIPTION
This should fix #867.

Chinese Yuan and Japanese Yen are both using symbol ￥, so it's not a good way to detect currency type from its symbol.

Steam gives a meta tag in HTML to show the currency (mentioned in #939, thought that bug is still not fixed right now), so we can just use it.

\* Updated: typo