### PR TITLE
Fixed missing US price by getting country code from inline script

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -406,6 +406,21 @@ function getStoreRegionCountryCode() {
 			matched = cookies.match(/steamCountry=([a-z]{2})/i);
 			if (matched != null && matched.length == 2) {
 				cc = matched[1];
+			} else if (window.g_oSuggestParams && g_oSuggestParams.cc) {
+				// country code is defined after an inline script executed
+				cc = g_oSuggestParams.cc;
+			} else {
+				// if not defined, we get the country code from the inline script
+				// that part looks like this, and the string 'CN' is what we want:
+				//     EnableSearchSuggestions( $J('#searchform')[0].elements['term'], '1_5_9_', 'CN', 'schinese', '1861747' );
+				var init_cc_script = $(".responsive_store_nav_ctn_spacer + script");
+				if (init_cc_script.length) {
+					var cc_script_text = init_cc_script.text();
+					matched = cc_script_text.match(/EnableSearchSuggestions\(.+'([a-z]{2})',.+\);/i);
+					if (matched != null && matched.length === 2) {
+						cc = matched[1];
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This should fix #939.

Sometimes both `steamCC...` and `steamCountry` are not defined in cookie, so the country code is always `us`. 

Here is a solution that mentioned in [#939L3](https://github.com/jshackles/Enhanced_Steam/issues/939#issuecomment-195963272). We can get country code from `g_oSuggestParams.cc`, but sometimes it's not defined. It's defined after an inline script executed, so we can match `CC` from the inline script.

BTW, from my test, this PR has no conflicts with PR #982, so both of them can be merged safety.

![US price shows successfully](https://cloud.githubusercontent.com/assets/8115912/14207614/cf897004-f84d-11e5-8bce-b64c8d97537c.png)
