### PR TITLE
Multiple requests due to fn call from "each"

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -699,7 +699,7 @@ function highlight_notinterested(node) {
 					}
 					setValue("dynamiclist_time", parseInt(Date.now() / 1000, 10));
 					deferred.resolve();
-				});
+				}, { async: false });
 			} else {
 				deferred.resolve();
 			}


### PR DESCRIPTION
"each" runs asynchronously which causes hundreds of requests(while viewing the wishlist at least) (based on how many items are on page) to [store.steampowered.com/dynamicstore/userdata/](http://store.steampowered.com/dynamicstore/userdata/) when calling **highlight_notinterested()** if the "dynamiclist_time" has expired or is not set.
This causes the browser be very slow or might even freeze on slower computers for a few seconds.

This is a fast dirty fix since async. requests are deprecated so we should look into fixing this properly.