### PR TITLE
FEATURE: Show the number of apps on sale

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -319,8 +319,8 @@ input[type=checkbox].es_dlc_selection:checked + label {
 }
 
 #es_dlc_option_panel {
-    background: url(http://cdn.steamcommunity.com/public/images/profile/profile_header_bg_texture.jpg);    
-    border-bottom: 1px solid black;
+	background: url(http://cdn.steamcommunity.com/public/images/profile/profile_header_bg_texture.jpg);	
+	border-bottom: 1px solid black;
 }
 
 .es_dlc_option {
@@ -537,9 +537,9 @@ input[type=checkbox].es_dlc_selection:checked + label {
 	-webkit-appearance: none;
 	border: none;
 	-webkit-transition: width 1s ease-in-out;
-    -moz-transition: width 1s ease-in-out;
-    -o-transition: width 1s ease-in-out;
-    transition: width 1s ease-in-out;
+	-moz-transition: width 1s ease-in-out;
+	-o-transition: width 1s ease-in-out;
+	transition: width 1s ease-in-out;
 }
 #es_progress.error, #es_progress.complete {
 	width:14px;
@@ -833,16 +833,16 @@ input[type=checkbox].es_dlc_selection:checked + label {
 	background: url('//steamcommunity-a.akamaihd.net/public/images/sharedfiles/ico_follow_tiled_lrg.png');
 }
 .performance-graph {
-    margin-top: -10px;
-    background: linear-gradient(135deg, rgba(97,100,101,0.3) 0%,rgba(226,244,255,0.3) 100%);
-    width: 98%;
-    border-radius: 6px;
-    border: 1px solid #524f4e;
-    overflow: hidden;
+	margin-top: -10px;
+	background: linear-gradient(135deg, rgba(97,100,101,0.3) 0%,rgba(226,244,255,0.3) 100%);
+	width: 98%;
+	border-radius: 6px;
+	border: 1px solid #524f4e;
+	overflow: hidden;
 }
 .performance-graph .row {
-    height: 18px;
-    overflow: hidden;
+	height: 18px;
+	overflow: hidden;
 }
 .performance-graph .row .nvidia {
 	background: #72b100;
@@ -859,17 +859,17 @@ input[type=checkbox].es_dlc_selection:checked + label {
 	 background: black;
 }
 .performance-graph .left-bar {
-    height: 100%;
-    text-align: center;
-    float: left;
-    position:relative;
+	height: 100%;
+	text-align: center;
+	float: left;
+	position:relative;
 }
 .performance-graph .right-bar {
-    background: rgba(0,0,0,0.0);
-    min-width:30px;
-    height: 100%;
-    text-align: left;
-    float: left;
+	background: rgba(0,0,0,0.0);
+	min-width:30px;
+	height: 100%;
+	text-align: left;
+	float: left;
 }
 .performance-graph .right-bar span {
 	padding-left: 5px;
@@ -912,14 +912,14 @@ input[type=checkbox].es_dlc_selection:checked + label {
 	bottom: 0;
 }
 .es_recentAchievements .achieveBar {
-    background: #3a3a3a;
-    padding: 1px;
-    border: 1px solid #aeaeae;
-    width: 176.9px;
+	background: #3a3a3a;
+	padding: 1px;
+	border: 1px solid #aeaeae;
+	width: 176.9px;
 }
 .es_recentAchievements .achieveBarProgress {
-    height: 8px;
-    background-color: #aeaeae;
+	height: 8px;
+	background-color: #aeaeae;
 }
 
 #es_customize_btn {
@@ -959,6 +959,7 @@ input[type=checkbox].es_dlc_selection:checked + label {
 
 /***************************************
  * Groups page
+ * groups_leave_options()
  **************************************/
 .es-group-leave-button {
 	background: linear-gradient(to bottom, #a4d007 5%, #536904 95%);
@@ -1022,3 +1023,19 @@ input[type=checkbox].es_dlc_selection:checked + label {
 }
 .es-leave-options button:focus {outline: none}
 .es-leave-options button:disabled {opacity: .6}
+
+/***************************************
+ * Store pages
+ * wishlist_on_sale_count()
+ **************************************/
+.es-discounted-count {
+	display: inline !important;
+	padding: 0 4px 1px 4px;
+	color: #fff !important;
+	border-radius: 2px;
+	font-size: 11px;
+	opacity: 0.8;
+}
+#wishlist_link:hover .es-discounted-count {
+	opacity: 1;
+}

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -1324,6 +1324,179 @@ function add_wishlist_filter() {
 	});
 }
 
+// Show the number of wishlisted apps on sale
+var wishlist_on_sale_count = (function() {
+	/*$('#store_header .content').prepend('<a id="clear_on_sale" style="float: left; cursor: pointer;">Clear on sale cache</a>');
+	$(document).on("click", "#clear_on_sale", function(e){
+		e.preventDefault();
+
+		chrome.storage.local.remove("wishlist_apps_on_sale");
+		console.log("Cleared on sale cache");		
+	});*/
+
+	function get(options){
+		//console.info('"get" was called');
+		var deferred = new $.Deferred();
+		if (is_signed_in) {
+			var defaults = {
+				forceUpdate : false
+			}
+			var settings = $.extend({}, defaults, options || {});
+			//console.log(settings);
+
+			var profileurl = $('.user_avatar')[0].href || $('.user_avatar a')[0].href,
+				expire_time = parseInt(Date.now() / 1000, 10) - 12 * 60 * 60, // 12 hours
+				expire_time_wl = parseInt(Date.now() / 1000, 10) - 120, // 2 minutes
+				last_updated = expire_time - 1,
+				wishlist_sale = wishlist_total = 0;
+
+			function count_set(wishlist_sale, wishlist_total) {
+				chrome.storage.local.set({
+					wishlist_apps_on_sale: {
+						wltotal: wishlist_total,
+						count: wishlist_sale,
+						updated: parseInt(Date.now() / 1000, 10)
+					}
+				});
+				//console.info("Storage set to", wishlist_sale, "on sale and", wishlist_total, "total");
+			}
+
+			chrome.storage.local.get("wishlist_apps_on_sale", function(cache){
+				if (cache.wishlist_apps_on_sale !== undefined) {
+					wishlist_sale = cache.wishlist_apps_on_sale.count;
+					wishlist_total = cache.wishlist_apps_on_sale.wltotal;
+					last_updated = cache.wishlist_apps_on_sale.updated;
+				}
+
+				// If viewing the Wishlist take advantage of that and update the number of apps on sale
+				if (/\/wishlist(\/)?$/.test(window.location.pathname) && $("#save_action_enabled_1").length && (last_updated < expire_time_wl || settings.forceUpdate)) {
+					wishlist_sale = $(".discount_block_inline").length;
+					wishlist_total = $(".wishlistRow").length;
+
+					//console.info("Updated from Wishlist page", wishlist_sale, "on sale", wishlist_total, "total");
+					count_set(wishlist_sale, wishlist_total);
+					deferred.resolve(wishlist_sale, wishlist_total);
+				// Pull the wishlist and count apps on sale if cache has expired
+				} else if (last_updated < expire_time || settings.forceUpdate) {
+					$.ajax({
+						url: profileurl + "wishlist/"
+					}).done(function(txt) {
+						var html = $.parseHTML(txt);
+						wishlist_sale = $(html).find(".discount_block_inline").length;
+						wishlist_total = $(html).find(".wishlistRow").length;
+
+						//console.info("Updated from a Store page", wishlist_sale, "on sale", wishlist_total, "total");
+						count_set(wishlist_sale, wishlist_total);
+						deferred.resolve(wishlist_sale, wishlist_total);
+					});
+				// Return from cache
+				} else {
+					//console.info("Returned from Storage", wishlist_sale, "on sale", wishlist_total, "total");
+					deferred.resolve(wishlist_sale, wishlist_total);
+				}
+			});
+		} else {
+			deferred.resolve();
+		}
+		return deferred.promise();
+	}
+
+	function display(){
+		//console.info('"display" was called');
+		if (is_signed_in) {
+			// Make sure the element we want to add the count to exists
+			if ($('#wishlist_item_count_value').length) {
+				get().done(function(wishlist_sale, wishlist_total) {
+					updateView(wishlist_sale, wishlist_total);
+				});
+			}
+		}
+	}
+
+	function updateView(wishlist_sale, wishlist_total){
+		//console.info('"updateView" was called');
+		// Make sure there are apps on sale and that the element we want to add the count to exists
+		if (wishlist_sale > 0 && $('#wishlist_item_count_value').length) {
+			// Monitor for adding/removing apps to/from wishlist
+			if ($("#add_to_wishlist_area").length) {
+				var on_wishlist_change = new MutationObserver(function() {
+					// Make sure the request has not failed
+					if (!$("#add_to_wishlist_area_fail").is(":visible")) {
+						//console.info('"Add to wishlist" button state changed');
+						var ammount = ($("#add_to_wishlist_area").is(":visible") ? -1 : 1);
+						var is_on_sale = false;
+						if ($('.game_purchase_action:first').find('.discount_block').length) {
+							is_on_sale = true;
+						}
+
+						changeBy(ammount, is_on_sale);
+					}
+					
+					this.disconnect();
+				});
+				on_wishlist_change.observe($("#add_to_wishlist_area")[0], {attributes: true, attributeFilter: ['style'], childList: false, subtree: false});
+			}
+
+			// Tooltip (is "of which" in locale correct?)
+			localized_strings.wishlist_count = "You have <b>__wishlist_count__</b> apps in your wishlist, of which <b>__wishlist_on_sale__</b> are on sale";
+
+			var wlLinkSel = '#wishlist_link';
+			// We need to remove and re-insert the Wishlist link to reset the toolip
+			if ($('.es-discounted-count').length) { // don't do it the first time, after page was loaded
+				$('.es-discounted-count').remove();
+				// Change wishlist total
+				$('#wishlist_item_count_value').text(wishlist_total);
+
+				$(wlLinkSel).after($(wlLinkSel).clone()).remove();
+			}
+			$(wlLinkSel).attr("data-store-tooltip", localized_strings.wishlist_count.replace("__wishlist_count__", wishlist_total).replace("__wishlist_on_sale__", wishlist_sale));
+			runInPageContext(function() { BindStoreTooltip( $J('[data-store-tooltip]') ); });
+
+			// Insert total on sale
+			$('#wishlist_item_count_value').append(' <span class="es-discounted-count discount_pct">' + wishlist_sale + '</span>');
+		}
+	}
+
+	function changeBy(ammount, is_on_sale) {
+		//console.info('"changeBy" was called');
+		if (is_signed_in) {
+			chrome.storage.local.get("wishlist_apps_on_sale", function(cache){
+				// The cache has be there already
+				if (cache.wishlist_apps_on_sale !== undefined) {
+					wishlist_sale = cache.wishlist_apps_on_sale.count;
+					wishlist_total = cache.wishlist_apps_on_sale.wltotal;
+
+					if (Number.isInteger(ammount)) {
+						wishlist_total = wishlist_total + ammount;
+						if (is_on_sale) {
+							wishlist_sale = wishlist_sale + ammount;
+						}
+
+						chrome.storage.local.set({
+							wishlist_apps_on_sale: {
+								wltotal: wishlist_total,
+								count: wishlist_sale,
+								updated: parseInt(Date.now() / 1000, 10)
+							}
+						});
+
+						//console.info("Changed count by", ammount, "to", wishlist_sale, "on sale" + (is_on_sale ? "(changed)" : "(not changed)") + " and", wishlist_total, "total");
+						updateView(wishlist_sale, wishlist_total);
+					}
+				} else {
+					//console.warn('Something went wrong, please refresh the page and try again!');
+				}
+			});
+		}
+	}
+	return {
+		get: get,
+		display: display,
+		updateView: updateView,
+		changeBy: changeBy
+	}
+})();
+
 function add_wishlist_discount_sort() {
 	if ($("#wishlist_sort_options").find("a[href$='price']").length > 0) {
 		$("#wishlist_sort_options").find("a[href$='price']").after("&nbsp;&nbsp;<label id='es_wl_sort_discount'><a>" + localized_strings.discount + "</a></label>");
@@ -1430,6 +1603,7 @@ function add_wishlist_ajaxremove() {
 		var session = decodeURIComponent(cookie.match(/sessionid=(.+?);/i)[1]);
 
 		$("#es_wishlist_remove_" + appid).on("click", function() {
+			var el = $(this);
 			$.ajax({
 				type:"POST",
 				url: window.location,
@@ -1448,6 +1622,12 @@ function add_wishlist_ajaxremove() {
 							$('.wishlist_rank')[i].value = $('.wishlist_rank')[i].value - 1;	
 						}
 					}
+					// Update the wishlist count
+					var is_on_sale = false;
+					if ($(el).parent().parent().find('.gameListPriceData .discount_block').length) {
+						is_on_sale = true;
+					}
+					wishlist_on_sale_count.changeBy(-1, is_on_sale);
 				}
 			});
 		});
@@ -1887,6 +2067,7 @@ function add_enhanced_steam_options() {
 	$clear_cache_link.click(function(){
 		localStorage.clear();
 		chrome.storage.local.remove("user_currency");
+		chrome.storage.local.remove("wishlist_apps_on_sale");
 		location.reload();
 	});
 
@@ -8347,6 +8528,7 @@ $(document).ready(function(){
 					hide_trademark_symbols();
 					set_html5_video();
 					get_store_session();
+					wishlist_on_sale_count.display();
 					break;
 
 				case "steamcommunity.com":
@@ -8365,6 +8547,7 @@ $(document).ready(function(){
 							add_wishlist_ajaxremove();
 							add_wishlist_pricehistory();
 							add_wishlist_notes();
+							wishlist_on_sale_count.get();
 
 							// Wishlist highlights
 							load_inventory().done(function() {

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -1333,6 +1333,15 @@ var wishlist_on_sale_count = (function() {
 		chrome.storage.local.remove("wishlist_counts");
 		console.log("Cleared on sale cache");		
 	});*/
+	var is_enabled = false;
+	storage.get(function(settings) {
+		if (settings.show_onsale_count === undefined) {
+			is_enabled = true;
+			storage.set({'show_onsale_count': is_enabled});
+		} else {
+			is_enabled = settings.show_onsale_count;
+		}
+	});
 
 	function count_set(wishlist_sale, wishlist_total) {
 		chrome.storage.local.set({
@@ -1348,7 +1357,7 @@ var wishlist_on_sale_count = (function() {
 	function get(options){
 		//console.info('"get" was called');
 		var deferred = new $.Deferred();
-		if (is_signed_in) {
+		if (is_signed_in && is_enabled) {
 			var defaults = {
 				forceUpdate : false
 			}
@@ -1405,7 +1414,7 @@ var wishlist_on_sale_count = (function() {
 
 	function display(){
 		//console.info('"display" was called');
-		if (is_signed_in) {
+		if (is_signed_in && is_enabled) {
 			// Make sure the element we want to add the count to exists
 			if ($("#wishlist_item_count_value").length) {
 				get().done(function(wishlist_sale, wishlist_total) {
@@ -1421,7 +1430,7 @@ var wishlist_on_sale_count = (function() {
 	function updateView(wishlist_sale, wishlist_total){
 		//console.info('"updateView" was called');
 		// Make sure there are apps on sale and that the element we want to add the count to exists
-		if ($("#wishlist_item_count_value").length) {
+		if (is_signed_in && is_enabled && $("#wishlist_item_count_value").length) {
 			// Monitor for adding/removing apps to/from wishlist
 			if ($("#add_to_wishlist_area").length) {
 				var on_wishlist_change = new MutationObserver(function() {
@@ -1461,7 +1470,7 @@ var wishlist_on_sale_count = (function() {
 
 	function changeBy(ammount, is_on_sale) {
 		//console.info('"changeBy" was called');
-		if (is_signed_in) {
+		if (is_signed_in && is_enabled) {
 			chrome.storage.local.get("wishlist_counts", function(cache){
 				// The cache has be there already
 				if (cache.wishlist_counts !== undefined) {

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -2064,7 +2064,7 @@ function add_enhanced_steam_options() {
 	$clear_cache_link.click(function(){
 		localStorage.clear();
 		chrome.storage.local.remove("user_currency");
-		chrome.storage.local.remove("wishlist_apps_on_sale");
+		chrome.storage.local.remove("wishlist_counts");
 		location.reload();
 	});
 

--- a/js/options.js
+++ b/js/options.js
@@ -36,6 +36,7 @@ function save_options() {
 	hideinstallsteambutton = $("#hideinstallsteambutton").prop('checked');
 	hideaboutmenu = $("#hideaboutmenu").prop('checked');
 	replaceaccountname = $("#replaceaccountname").prop('checked');
+	show_onsale_count = $("#show_onsale_count").prop('checked');
 	showfakeccwarning = $("#showfakeccwarning").prop('checked');
 	showlanguagewarning = $("#showlanguagewarning").prop('checked');
 	showlanguagewarninglanguage = $("#warning_language").val();
@@ -185,6 +186,7 @@ function save_options() {
 		'hideinstallsteambutton': hideinstallsteambutton,
 		'hideaboutmenu': hideaboutmenu,
 		'replaceaccountname': replaceaccountname,
+		'show_onsale_count': show_onsale_count,
 		'showfakeccwarning': showfakeccwarning,
 		'showlanguagewarning': showlanguagewarning,
 		'showlanguagewarninglanguage': showlanguagewarninglanguage,
@@ -432,6 +434,7 @@ function load_options() {
 		if (settings.hideinstallsteambutton === undefined) { settings.hideinstallsteambutton = false; storage.set({'hideinstallsteambutton': settings.hideinstallsteambutton}); }
 		if (settings.hideaboutmenu === undefined) { settings.hideaboutmenu = false; storage.set({'hideaboutmenu': settings.hideaboutmenu}); }
 		if (settings.replaceaccountname === undefined) { settings.replaceaccountname = false; storage.set({'replaceaccountname': settings.replaceaccountname}); }
+		if (settings.show_onsale_count === undefined) { settings.show_onsale_count = false; storage.set({'show_onsale_count': settings.show_onsale_count}); }
 		if (settings.showfakeccwarning === undefined) { settings.showfakeccwarning = true; storage.set({'showfakeccwarning': settings.showfakeccwarning}); }
 		if (settings.showlanguagewarning === undefined) { settings.showlanguagewarning = true; storage.set({'showlanguagewarning': settings.showlanguagewarning}); }
 		if (settings.showlanguagewarninglanguage === undefined) { settings.showlanguagewarninglanguage = "English"; storage.set({'showlanguagewarninglanguage': settings.showlanguagewarninglanguage}); }
@@ -503,6 +506,7 @@ function load_options() {
 		$("#hideinstallsteambutton").prop('checked', settings.hideinstallsteambutton);
 		$("#hideaboutmenu").prop('checked', settings.hideaboutmenu);
 		$("#replaceaccountname").prop('checked', settings.replaceaccountname);
+		$("#show_onsale_count").prop('checked', settings.show_onsale_count);
 		$("#showfakeccwarning").prop('checked', settings.showfakeccwarning);
 		$("#showlanguagewarning").prop('checked', settings.showlanguagewarning);
 		$("#warning_language").val(settings.showlanguagewarninglanguage);
@@ -677,6 +681,7 @@ function load_translation() {
 			$("#store_hide_install_text").text(localized_strings.options.hide_install);
 			$("#store_hide_about_menu").text(localized_strings.options.hide_about);
 			$("#store_replace_account_name").text(localized_strings.options.replace_account_name);
+			$("#show_onsale_count_text").text(localized_strings.options.show_onsale_count_text);
 			$("#store_general").text(localized_strings.options.general);
 			$("#header_showfakeccwarning_text").text(localized_strings.options.show_regionwarning);
 			$("#store_show_languagewarning_text").text(localized_strings.options.show_languagewarning);

--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -215,6 +215,7 @@
     "leave_group_admin_confirm": "You are Admin in this group: __groupname__\nAre you sure you want to leave?",
     "wrong_try_again": "Something went wrong. Please try again.",
     "join_group": "Join Group",
+    "wishlist_counts_tooltip": "You have <b>__wishlist_total__</b> apps on your wishlist, <b>__wishlist_on_sale__</b> are on sale",
     "achievements": {
         "option": "Show achievements on store pages",
         "achievements": "Achievements",

--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -269,6 +269,7 @@
         "contscroll": "Enable continuous scrolling of search results",
         "profile_link_images_none": "None",
         "replace_account_name": "Replace account name with community name",
+        "show_onsale_count_text": "Show the number of apps on sale in the \"Wishlist\" button",
         "profile_links": "Show profile links to",
         "library_header": "Library (BETA)",
         "tag": "Tag",

--- a/options.html
+++ b/options.html
@@ -179,6 +179,7 @@
 				</li>
 				<li class="header" id="store_general">General</li>
 				<li><input type="checkbox" id="replaceaccountname"><label for="replaceaccountname" id="store_replace_account_name">Replace account name with community name</label></li>
+				<li><input type="checkbox" id="show_onsale_count"><label for="show_onsale_count" id="show_onsale_count_text">Show the number of apps on sale in the "Wishlist" button</label></li>
 				<li><input type="checkbox" id="showfakeccwarning"><label for="showfakeccwarning" id="header_showfakeccwarning_text">Show warning if browsing in non-account region</label></li>
 				<li><input type="checkbox" id="send_age_info"><label for="send_age_info" id="send_age_info_text">Automatically send age verification when requested</label></li>
 				<li><input type="checkbox" id="html5video"><label for="html5video" id="html5video_text">Show videos using HTML5 instead of Flash</label></li>


### PR DESCRIPTION
* Shows the number of wishlisted apps on sale near the number of
wishlisted apps. I've seen this requested on Steam subreddit, thought it
might be nice to have it in ES.
* Updates the total number of wishlisted apps and apps on sale when add/removing apps to/from wishlist from a store page
* Cleaned up space indentations in main CSS file

![chrome_2016-04-18_00-17-05](https://cloud.githubusercontent.com/assets/3322834/14590737/7470c908-0502-11e6-97cc-9afc69bdcfaa.png)



Known issues:
* Adding/removing apps to/from wishlist that were or were not already on the wishlist (from already opened tabs with the same app for eg.) will cause the count to be wrong.
  * CAUSE: This happens due to all add/remove requests being treated as successful while the requests might carry a "failed" response.
  * FIX: To fix it we would have to create a new function to replace the one Steam uses to add to wishlist and combine it with [the method we use to remove from wishlist](https://github.com/jshackles/Enhanced_Steam/blob/master/enhancedsteam.js#L6634-#L6665) and use that instead of a MutationObserver.