### PR TITLE
Wishlist sorting improvements

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -1361,13 +1361,13 @@ function add_wishlist_discount_sort() {
 				sort_wishlist(".discount_pct", sort_by, true, function(val){
 					return parseInt(val);
 				});
-			break;
+				break;
 		}
 		
 		reset_sort_links($(this));
 	});
 
-	// Initiated "discounted" sort if necessary and rebuild sorting links
+	// Initiate "discounted" sort if necessary and rebuild sorting links
 	if (getCookie("wishlist_sort2") == "discount") {
 		$(".by_discount").click();
 	} else {

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -1342,7 +1342,7 @@ function add_wishlist_discount_sort() {
 		var sort_by = $(this).data("sort-by");
 		switch (sort_by) {
 			case "rank":
-				sort_wishlist(".wishlist_rank", sort_by, true);
+				sort_wishlist(".wishlist_rank, .wishlist_rank_ro", sort_by, true);
 				break;
 			case "added":
 				// Can't do this one... could make a request for it tho...
@@ -1354,7 +1354,7 @@ function add_wishlist_discount_sort() {
 				break;
 			case "price":
 				sort_wishlist(".price, .discount_final_price", sort_by, true, function(val){
-					return Number(val.replace(/[^0-9\.]+/g, "")) || 31337;
+					return Number(val.replace(/\-/g, "0").replace(/[^0-9\.]+/g, "")) || 31337;
 				});
 				break;
 			case "discount":


### PR DESCRIPTION
* Added ability to sort by "rank", "name", "price" or "discount" without
the page reloading
* The "discount" sorting is faster
* The state of the sorting is saved in a cookie (as Steam does) and
works for "discounted" too

There is no live sorting for "date added" since there is no data to work
with on the page and didn't wanted to make a request for it. So this one
works as before.