### PR TITLE
add_wishlist_filter() optimizations

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -1417,3 +1417,15 @@ input[type=checkbox].es_dlc_selection:checked + label {
 .es_games_filter {
 	float: left;
 }
+
+/***************************************
+ * Wishlist
+ * add_wishlist_filter()
+ **************************************/
+.es_wishlist_filter {
+    margin-top: 10px;
+}
+#save_action_disabled_1,
+#save_action_enabled_2 {
+	margin-top: -10px;
+}

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -1327,35 +1327,24 @@ function add_wishlist_filter() {
 		html += "<label class='es_sort' id='es_wl_coupon'><input type='radio' id='es_wl_coupon_box' name='es_wl_sort'><span><a>" + localized_strings.games_coupon + "</a></span></label>";
 		html += "</div>";
 
-	$('#wishlist_sort_options').append("<p>" + html);
+	$("#wishlist_sort_options").append("<div class='es_wishlist_filter'>" + html + "</div>");
 
+	$(".es_sort input").on("change", function() {
+		var parentId = $(this).parent()[0].id;
 
-	$('#es_wl_all').on('click', function() {
 		$(".es_lowest_price").remove();
-		$('#es_wl_all_box').prop('checked', true);
-		$('.wishlistRow').css('display', 'block');
-	});
 
-	$('#es_wl_sale').on('click', function() {
-		$(".es_lowest_price").remove();
-		$('#es_wl_sale_box').prop('checked', true);
-		$('.wishlistRow').css('display', 'block');
-		$('.wishlistRow').each(function () {
-			if (!$(this).html().match(/discount_block_inline/)) {
-				$(this).css('display', 'none');
-			}
-		});
-	});
-
-	$('#es_wl_coupon').on('click', function() {
-		$(".es_lowest_price").remove();
-		$('#es_wl_coupon_box').prop('checked', true);
-		$('.wishlistRow').css('display', 'block');
-		$('.wishlistRow').each(function () {
-			if (!$(this)[0].outerHTML.match(/es_highlight_coupon/)) {
-				$(this).css('display', 'none');
-			}
-		});
+		if (parentId === "es_wl_sale") {
+			$(".wishlistRow").hide();
+			$(".discount_block_inline").closest(".wishlistRow").show();
+		}
+		else if (parentId === "es_wl_coupon") {
+			$(".wishlistRow").hide();
+			$(".es_highlight_coupon").show();
+		}
+		else {
+			$(".wishlistRow").show();
+		}
 	});
 }
 


### PR DESCRIPTION
* fixed a bug with labels on radio inputs that have "click" bound to them which trigger the "click" event twice and basically causing the code to also be ran twice
* no longer uses "each" over wishlist rows, which makes things faster
* slightly decreased the vertical movement of the page when the filter options are injected