### PR TITLE
Prevent carousel items overflowing

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -1126,7 +1126,9 @@ input[type=checkbox].es_dlc_selection:checked + label {
 	position: relative;
 	height: 353px;
 }
-
+.es_carousel_desc {
+	max-height: 459px;
+}
 /***************************************
  * Steam inventory
  * inventory_market_helper()

--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -1107,12 +1107,18 @@ input[type=checkbox].es_dlc_selection:checked + label {
 	height: auto !important;
 }
 .es_carousel_desc .main_cap_desc,
+.es_carousel_desc .cluster_capsule,
 .es_carousel_desc .cluster_maincap_fill  {
 	transition: height 0.2s, max-height 0.2s, ease;
 }
 .es_carousel_desc .main_cap_desc {
 	height: 98px !important;
 	padding: 0 12px 8px 12px !important;
+}
+@media (max-width: 590px) { /* description text may overflow when this small */
+	.es_carousel_desc .main_cap_desc {
+		height: 122px !important;
+	}
 }
 .es_main_cap_status {
 	font-size: 12px !important;
@@ -1124,7 +1130,9 @@ input[type=checkbox].es_dlc_selection:checked + label {
 .es_carousel_desc .cluster_maincap_fill,
 .es_carousel_desc .es_capsule_image_wrap {
 	position: relative;
-	height: 353px;
+}
+.cluster_maincap_fill_placeholder {
+	display: block;
 }
 .es_carousel_desc {
 	max-height: 459px;

--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -1129,6 +1129,7 @@ input[type=checkbox].es_dlc_selection:checked + label {
 .es_carousel_desc {
 	max-height: 459px;
 }
+
 /***************************************
  * Steam inventory
  * inventory_market_helper()

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -6854,7 +6854,7 @@ function add_carousel_descriptions() {
 					$(window).on("resize", function(){
 						$(".es_carousel_desc").css("max-height", $("a.cluster_capsule").first().height());
 					});
-				}, 100);
+				}, 200);
 
 				// purge stale information from localStorage				
 				var i = 0, sKey;

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -6850,6 +6850,10 @@ function add_carousel_descriptions() {
 							$desc.append(value_to_add);
 						}
 					});
+
+					$(window).on("resize", function(){
+						$(".es_carousel_desc").css("max-height", $("a.cluster_capsule").first().height());
+					});
 				}, 100);
 
 				// purge stale information from localStorage				


### PR DESCRIPTION
This only prevents the items overflowing if something goes wrong with
the width calculations for #main_cluster_scroll but won't fix the issue that
led to that.