### PR TITLE
Currency conversion rates fail safe

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -417,7 +417,13 @@ var currencyConversion = (function() {
 				rates = JSON.parse(txt);
 				cache_set(currency || user_currency, rates);
 				deferred.resolveWith(rates);
-			}).fail(deferred.reject);
+			}).fail(function(){
+				rates = cache_get(currency || user_currency, true);
+				if (rates) {
+					deferred.resolveWith(rates);
+				}
+				deferred.reject();
+			});
 		}
 		return deferred.promise();
 	}
@@ -436,9 +442,9 @@ var currencyConversion = (function() {
 		};
 		localStorage.setItem("currencyConversion_" + currency, JSON.stringify(cached));
 	}
-	function cache_get(currency) {
+	function cache_get(currency, fail_safe) {
 		var cached = JSON.parse(localStorage.getItem("currencyConversion_" + currency));
-		if (cached && cached.expires > parseInt(Date.now() / 1000, 10)) {
+		if (cached && (cached.expires > parseInt(Date.now() / 1000, 10) || fail_safe)) {
 			var rates = {};
 			rates[currency] = cached.rates;
 			return rates;

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -417,12 +417,13 @@ var currencyConversion = (function() {
 				rates = JSON.parse(txt);
 				cache_set(currency || user_currency, rates);
 				deferred.resolveWith(rates);
-			}).fail(function(){
+			}, {timeout: 10000}).fail(function(){
 				rates = cache_get(currency || user_currency, true);
 				if (rates) {
 					deferred.resolveWith(rates);
+				} else {
+					deferred.reject();
 				}
-				deferred.reject();
 			});
 		}
 		return deferred.promise();

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -443,9 +443,9 @@ var currencyConversion = (function() {
 		};
 		localStorage.setItem("currencyConversion_" + currency, JSON.stringify(cached));
 	}
-	function cache_get(currency, fail_safe) {
+	function cache_get(currency, get_cached) {
 		var cached = JSON.parse(localStorage.getItem("currencyConversion_" + currency));
-		if (cached && (cached.expires > parseInt(Date.now() / 1000, 10) || fail_safe)) {
+		if (cached && (cached.expires > parseInt(Date.now() / 1000, 10) || get_cached)) {
 			var rates = {};
 			rates[currency] = cached.rates;
 			return rates;


### PR DESCRIPTION
At the time I'm writing this the ES API is down and the retrieval of
currency conversion rates fails making dependent functions to also fail.
So from now on when this happens we fallback to cache.