### PR TITLE
add_wishlist_total() optimizations

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -129,16 +129,6 @@ img.platform_small, .platform_img {
 .apphub_HeaderTop.es_greenlight.es_released {
 	background-image: url('http://cdn.steamcommunity.com/public/images/sharedfiles/ig/gl_item_green_shiny.jpg');
 }
-#es_empty_wishlist,#es_empty_owned_wishlist {
-	width:auto;
-	display:inline-block;
-	padding:0 5px 0 5px;
-	border-color:#af1900;
-	color:#af1900;
-}
-#es_empty_owned_wishlist {
-	margin-left:6px;
-}
 .wishlistRowItem {
 	overflow: initial !important;
 }
@@ -1381,6 +1371,18 @@ input[type=checkbox].es_dlc_selection:checked + label {
 	padding-right: 12px;
 	height: 24px;
 }
+/* ES specific */
+.es_wishlist_total,
+.es_show_wishlist_total {
+	width: 100%;
+	margin-top: 20px;
+	display: inline-block;
+	clear: both;
+}
+.es_show_wishlist_total span {
+	padding: 10px;
+	text-align: center;
+}
 
 /***************************************
  * Wishlist
@@ -1415,7 +1417,7 @@ input[type=checkbox].es_dlc_selection:checked + label {
 	outline: none;
 	padding: 4px 6px;
 }
-/* ES Specific */
+/* ES specific */
 .es_games_filter {
 	float: left;
 }
@@ -1428,7 +1430,7 @@ input[type=checkbox].es_dlc_selection:checked + label {
 	margin-top: 10px;
 }
 #save_action_disabled_1,
-#save_action_enabled_2 {
+#save_action_enabled_1 {
 	margin-top: -10px;
 }
 
@@ -1528,6 +1530,30 @@ input[type=checkbox].es_dlc_selection:checked + label {
 	100% {
 		white-space: normal;
 	}
+}
+
+/***************************************
+ * Wishlist
+ * add_empty_wishlist_buttons()
+ **************************************/
+#es_empty_wishlist {
+	width: auto;
+	display: inline-block;
+	padding: 0 5px 0 5px;
+	border-color: #af1900;
+	color: #af1900;
+	float: right;
+}
+#save_action_enabled_2 .btn_small {
+	float: left;
+}
+#save_action_enabled_2 .save_button_nag {
+	float: left;
+	margin: 3px 10px;
+}
+#save_action_enabled_2,
+#save_action_disabled_2 {
+	float: left;
 }
 
 /***************************************

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -1457,37 +1457,57 @@ function add_wishlist_discount_sort() {
 }
 
 // Calculate total cost of all items on wishlist
-function add_wishlist_total() {
-	var total = 0;
-	var gamelist = "";
-	var items = 0;
-	var apps = "";
+function add_wishlist_total(showTotal) {
+	if ($('.wishlistRow').length < 100 || showTotal) {
+		var total = 0,
+			items = 0,
+			gamelist = "",
+			apps = "";
 
-	function calculate_node($node, search) {
-		var parsed = parse_currency($node.find(search).text().trim());
+		function calculate_node($node, search) {
+			var parsed = parse_currency($node.find(search).text().trim());
 
-		if (parsed) {
-			gamelist += $node.find("h4").text().trim() + ", ";
-			items ++;
-			total += parsed.value;
-			apps += get_appid($node.find(".btnv6_blue_hoverfade").attr("href")) + ",";
+			if (parsed) {
+				gamelist += $node.find("h4").text().trim() + ", ";
+				total += parsed.value;
+				apps += get_appid($node.find(".btnv6_blue_hoverfade").attr("href")) + ",";
+				items ++;
+			}
 		}
+
+		$('.wishlistRow').each(function(){
+			var $this = $(this);
+
+			if ($this.find("div[class='price']").length != 0 && $this.find("div[class='price']").text().trim() != "")
+				calculate_node($this, "div[class='price']");
+
+			if ($this.find("div[class='discount_final_price']").length != 0)
+				calculate_node($this, "div[class='discount_final_price']");
+		});
+		gamelist = gamelist.replace(/, $/, "");
+
+		total = formatCurrency(parseFloat(total));
+
+		$(".games_list").after(`
+			<div class='es_wishlist_total'>
+				<div class='game_area_purchase_game'>
+					<h1>` + localized_strings.wishlist + `</h1>
+					<p class='package_contents'><b>` + localized_strings.bundle.includes.replace("__num__", items) + `:</b> ` + gamelist + `</p>
+					<div class='game_purchase_action'>
+						<div class='game_purchase_action_bg'>
+							<div class='game_purchase_price price'>` + total + `</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		`);
+	} else {
+		$(".games_list").after("<div class='es_show_wishlist_total btn_darkblue_white_innerfade'><span>" + localized_strings.show_wishlist_total + "<span></div>");
+		$(document).on("click", ".es_show_wishlist_total", function(){
+			$(this).remove();
+			add_wishlist_total(true);
+		});
 	}
-
-	$('.wishlistRow').each(function () {
-		var $this = $(this);
-
-		if ($this.find("div[class='price']").length != 0 && $this.find("div[class='price']").text().trim() != "")
-			calculate_node($this, "div[class='price']");
-
-		if ($this.find("div[class='discount_final_price']").length != 0)
-			calculate_node($this, "div[class='discount_final_price']");
-	});
-	gamelist = gamelist.replace(/, $/, "");
-
-	total = formatCurrency(parseFloat(total));
-
-	$(".games_list").after("<div class='es_wishlist_total'><div class='game_area_purchase_game' style='width: 600px; margin-top: 15px;'><h1>" + localized_strings.wishlist + "</h1><p class='package_contents'><b>" + localized_strings.bundle.includes.replace("__num__", items) + ":</b> " + gamelist + "</p><div class='game_purchase_action'><div class='game_purchase_action_bg'><div class='game_purchase_price price'>" + total + "</div></div></div></div></div></div></div>");
 }
 
 function add_wishlist_ajaxremove() {

--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -228,6 +228,7 @@
     "early_access": "Early Access",
     "filter_games": "Filter games",
     "note_for": "Note for",
+    "show_wishlist_total": "Show wishlist Total",
     "achievements": {
         "option": "Show achievements on store pages",
         "achievements": "Achievements",


### PR DESCRIPTION
When accessing the Wishlist, having many wishlisted apps can make the
page freeze or stutter for a few moments, which sucks since it looks as
it's done loading and ready to interact with. So, if there are too many
items, we display a button which will load the wishlist total when/if
needed.

(This alone doesn't fix the stuttering issue completely but it helps)