### PR TITLE
Force credentials

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -132,7 +132,7 @@ var signed_in_promise = (function () {
 						setValue("steamID", is_signed_in);
 					}
 					deferred.resolve();
-				});
+				}, { xhrFields: {withCredentials: true} });
 			}
 		} else {
 			deferred.resolve();


### PR DESCRIPTION
When requesting steamcommunity.com/profiles/0/ via AJAX Chrome automatically attaches the cookies to the request, Firefox doesn't seem to do the same.