### PR TITLE
FIX: Language reset not working

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -2199,10 +2199,10 @@ function add_language_warning() {
 							<a href="#" id="es_reset_language_code">` + localized_strings_native.using_language_return.replace("__base__", localized_strings_native.options.lang[warning_language.toLowerCase()]) + `</a>
 						</div>
 					`);
-					$("#es_reset_language_code").click(function(e) {
+					$("#es_reset_language_code").on("click", function(e) {
 						e.preventDefault();
-						document.cookie = 'Steam_Language=' + settings.showlanguagewarninglanguage.toLowerCase() + ';path=/;';
-						window.location.replace(window.location.href.replace(/[?&]l=[a-z]+/, ""));
+
+						runInPageContext("function(){ ChangeLanguage( '" + settings.showlanguagewarninglanguage.toLowerCase() + "' ) }");
 					});
 				});
 			}


### PR DESCRIPTION
There seems to be some changes to the way the language is set. A simple
cookie change on steamcommunity.com no longer works and there is a
request to http://steamcommunity.com/actions/SetLanguage/ involved.
This is needed most likely because now the language selection is shared
with the Steam app.

To fix this we'll simply use Steam's method for changing the language.