### PR TITLE
Cleaned and simplified code in Options page

### DIFF
--- a/css/options.css
+++ b/css/options.css
@@ -208,17 +208,13 @@ a:hover {
 	margin-top:5px;
 	width:auto;
 }
-#show_spamcommentregex {
-	margin-left:5px;
-	color:#EFFFEF;
-}
 #spamcommentregex_list {
 	margin-left:10px;
 	margin-bottom:5px;
 	display:none;
 }
+#show_spamcommentregex,
 #show_quickinv_diff {
-	margin-left:5px;
 	color:#EFFFEF;
 }
 #quickinv_opt {

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -1585,7 +1585,7 @@ function add_wishlist_pricehistory() {
 			// Get List of stores we're searching for
 			var storestring = "";
 			$.each(settings.stores, function(store, value) {
-				if (settings.stores[store] === true) {
+				if (settings.stores[store] === true || settings.showallstores) {
 					storestring += store + ",";
 				}
 			});

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -1546,142 +1546,152 @@ function add_wishlist_pricehistory() {
 		if (settings.showlowestpricecoupon === undefined) { settings.showlowestpricecoupon = true; storage.set({'showlowestpricecoupon': settings.showlowestpricecoupon}); }
 		if (settings.showlowestprice_region === undefined) { settings.showlowestprice_region = "us"; storage.set({'showlowestprice_region': settings.showlowestprice_region}); }
 		if (settings.showallstores === undefined) { settings.showallstores = true; storage.set({'showallstores': settings.showallstores}); }
-		if (settings.stores === undefined) { settings.stores = [true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true]; storage.set({'stores': settings.stores}); }
-		if (settings.showlowestprice_onwishlist) {
+		if (settings.stores === undefined || settings.stores instanceof Array) {
+			settings.stores = {
+				"steam": true,
+				"amazonus": true,
+				"impulse": true,
+				"gamersgate": true,
+				"greenmangaming": true,
+				"direct2drive": true,
+				"origin": true,
+				"uplay": true,
+				"indiegalastore": true,
+				"gamesplanet": true,
+				"indiegamestand": true,
+				"gog": true,
+				"dotemu": true,
+				"nuuvem": true,
+				"dlgamer": true,
+				"humblestore": true,
+				"squenix": true,
+				"bundlestars": true,
+				"fireflower": true,
+				"humblewidgets": true,
+				"newegg": true,
+				"gamesrepublic": true,
+				"coinplay": true,
+				"funstock": true,
+				"wingamestore": true,
+				"gamebillet": true,
+				"silagames": true,
+				"playfield": true,
+				"imperialgames": true
+			};
+			storage.set({'stores': settings.stores});
+		}
 
+		if (settings.showlowestprice_onwishlist) {
 			// Get List of stores we're searching for
 			var storestring = "";
-			if (settings.stores[0]) { storestring += "steam,"; }
-			if (settings.stores[1]) { storestring += "amazonus,"; }
-			if (settings.stores[2]) { storestring += "impulse,"; }
-			if (settings.stores[3]) { storestring += "gamersgate,"; }
-			if (settings.stores[4]) { storestring += "greenmangaming,"; }
-			if (settings.stores[5]) { storestring += "direct2drive,"; }
-			if (settings.stores[6]) { storestring += "origin,"; }
-			if (settings.stores[7]) { storestring += "uplay,"; }
-			if (settings.stores[8]) { storestring += "indiegalastore,"; }
-			if (settings.stores[10]) { storestring += "gamesplanet,"; }
-			if (settings.stores[13]) { storestring += "gog,"; }
-			if (settings.stores[14]) { storestring += "dotemu,"; }
-			if (settings.stores[17]) { storestring += "nuuvem,"; }
-			if (settings.stores[19]) { storestring += "dlgamer,"; }
-			if (settings.stores[20]) { storestring += "humblestore,"; }
-			if (settings.stores[21]) { storestring += "indiegamestand,"; }
-			if (settings.stores[22]) { storestring += "squenix,"; }
-			if (settings.stores[23]) { storestring += "bundlestars,"; }
-			if (settings.stores[24]) { storestring += "fireflower,"; }
-			if (settings.stores[25]) { storestring += "humblewidgets,"; }
-			if (settings.stores[26]) { storestring += "newegg,"; }
-			if (settings.stores[27]) { storestring += "gamesrepublic,"; }
-			if (settings.stores[28]) { storestring += "coinplay,"; }
-			if (settings.stores[29]) { storestring += "funstock,"; }
-			if (settings.stores[30]) { storestring += "wingamestore,"; }
-			if (settings.stores[31]) { storestring += "gamebillet,"; }
-			if (settings.stores[32]) { storestring += "silagames,"; }
-			if (settings.stores[33]) { storestring += "playfield,"; }
-			if (settings.stores[34]) { storestring += "imperialgames,"; }
-			if (settings.showallstores) { storestring = "steam,amazonus,impulse,gamersgate,greenmangaming,direct2drive,origin,uplay,indiegalastore,gamesplanet,gog,dotemu,nuuvem,dlgamer,humblestore,squenix,bundlestars,fireflower,humblewidgets,newegg,gamesrepublic,coinplay,funstock,wingamestore,gamebillet,silagames,playfield,imperialgames"; }
+			$.each(settings.stores, function(store, value) {
+				if (settings.stores[store] === true) {
+					storestring += store + ",";
+				}
+			});
 
-			// Get country code from Steam cookie
-			var cc = getStoreRegionCountryCode();
+			if (storestring !== "") {
+				// Get country code from Steam cookie
+				var cc = getStoreRegionCountryCode();
 
-			function get_price_data(lookup_type, node, id) {
-				html = "<div class='es_lowest_price' id='es_price_" + id + "'><div class='gift_icon' id='es_line_chart_" + id + "'><img src='" + chrome.extension.getURL("img/line_chart.png") + "'></div><span id='es_price_loading_" + id + "'>" + localized_strings.loading + "</span>";
-				$(node).append(html);
+				function get_price_data(lookup_type, node, id) {
+					html = "<div class='es_lowest_price' id='es_price_" + id + "'><div class='gift_icon' id='es_line_chart_" + id + "'><img src='" + chrome.extension.getURL("img/line_chart.png") + "'></div><span id='es_price_loading_" + id + "'>" + localized_strings.loading + "</span>";
+					$(node).append(html);
 
-				get_http("//api.enhancedsteam.com/pricev2/?search=" + lookup_type + "/" + id + "&stores=" + storestring + "&cc=" + cc + "&coupon=" + settings.showlowestpricecoupon, function (txt) {
-					var data = JSON.parse(txt);
-					if (data) {
-						var activates = "", line1 = "", line2 = "", line3 = "", html, recorded, lowest, lowesth;
-						var currency_type = data[".meta"]["currency"];
+					get_http("//api.enhancedsteam.com/pricev2/?search=" + lookup_type + "/" + id + "&stores=" + storestring + "&cc=" + cc + "&coupon=" + settings.showlowestpricecoupon, function (txt) {
+						var data = JSON.parse(txt);
+						if (data) {
+							var activates = "", line1 = "", line2 = "", line3 = "", html, recorded, lowest, lowesth;
+							var currency_type = data[".meta"]["currency"];
 
-						// "Lowest Price"
-						if (data["price"]) {
-							if (data["price"]["drm"] == "steam") {
-								activates = "(<b>" + localized_strings.activates + "</b>)";
-								if (data["price"]["store"] == "Steam") {
-									activates = "";
+							// "Lowest Price"
+							if (data["price"]) {
+								if (data["price"]["drm"] == "steam") {
+									activates = "(<b>" + localized_strings.activates + "</b>)";
+									if (data["price"]["store"] == "Steam") {
+										activates = "";
+									}
+								}
+
+								if (settings.override_price != "auto") {
+									currencyConversion.load().done(function() {
+										lowest = currencyConversion.convert(data["price"]["price"], data[".meta"]["currency"], settings.override_price);
+										currency_type = settings.override_price;
+									});
+								} else {
+									lowest = data["price"]["price"].toString();
+								}
+
+								line1 = localized_strings.lowest_price + ': ' + localized_strings.lowest_price_format.replace("__price__", formatCurrency(lowest, currency_type)).replace("__store__", '<a href="' + escapeHTML(data["price"]["url"].toString()) + '" target="_blank">' + escapeHTML(data["price"]["store"].toString()) + '</a>') + ' ' + activates + ' (<a href="' + escapeHTML(data["urls"]["info"].toString()) + '" target="_blank">' + localized_strings.info + '</a>)';
+								if (settings.showlowestpricecoupon) {
+									if (data["price"]["price_voucher"]) {
+										line1 = localized_strings.lowest_price + ': ' + localized_strings.lowest_price_format.replace("__price__", formatCurrency(lowest, currency_type)).replace("__store__", '<a href="' + escapeHTML(data["price"]["url"].toString()) + '" target="_blank">' + escapeHTML(data["price"]["store"].toString()) + '</a>') + ' ' + localized_strings.after_coupon + ' <b>' + escapeHTML(data["price"]["voucher"].toString()) + '</b> ' + activates + ' (<a href="' + escapeHTML(data["urls"]["info"].toString()) + '" target="_blank">' + localized_strings.info + '</a>)';
+									}
 								}
 							}
 
-							if (settings.override_price != "auto") {
-								currencyConversion.load().done(function() {
-									lowest = currencyConversion.convert(data["price"]["price"], data[".meta"]["currency"], settings.override_price);
-									currency_type = settings.override_price;
-								});
-							} else {
-								lowest = data["price"]["price"].toString();
-							}
-
-							line1 = localized_strings.lowest_price + ': ' + localized_strings.lowest_price_format.replace("__price__", formatCurrency(lowest, currency_type)).replace("__store__", '<a href="' + escapeHTML(data["price"]["url"].toString()) + '" target="_blank">' + escapeHTML(data["price"]["store"].toString()) + '</a>') + ' ' + activates + ' (<a href="' + escapeHTML(data["urls"]["info"].toString()) + '" target="_blank">' + localized_strings.info + '</a>)';
-							if (settings.showlowestpricecoupon) {
-								if (data["price"]["price_voucher"]) {
-									line1 = localized_strings.lowest_price + ': ' + localized_strings.lowest_price_format.replace("__price__", formatCurrency(lowest, currency_type)).replace("__store__", '<a href="' + escapeHTML(data["price"]["url"].toString()) + '" target="_blank">' + escapeHTML(data["price"]["store"].toString()) + '</a>') + ' ' + localized_strings.after_coupon + ' <b>' + escapeHTML(data["price"]["voucher"].toString()) + '</b> ' + activates + ' (<a href="' + escapeHTML(data["urls"]["info"].toString()) + '" target="_blank">' + localized_strings.info + '</a>)';
+							// "Historical Low"
+							if (data["lowest"]) {
+								if (settings.override_price != "auto") {
+									currencyConversion.load().done(function() {
+										lowesth = currencyConversion.convert(data["lowest"]["price"], data[".meta"]["currency"], settings.override_price);
+										currency_type = settings.override_price;
+									});
+								} else {
+									lowesth = data["lowest"]["price"].toString();
 								}
+								recorded = new Date(data["lowest"]["recorded"]*1000);
+								line2 = localized_strings.historical_low + ': ' + localized_strings.historical_low_format.replace("__price__", formatCurrency(lowesth, currency_type)).replace("__store__", escapeHTML(data["lowest"]["store"].toString())).replace("__date__", recorded.toLocaleDateString()) + ' (<a href="' + escapeHTML(data["urls"]["history"].toString()) + '" target="_blank">' + localized_strings.info + '</a>)';
+							}
+
+							// "Number of times this game has been in a bundle"
+							if (data["bundles"]["count"] > 0) {
+								line3 = "<br>" + localized_strings.bundle.bundle_count + ": " + data["bundles"]["count"] + ' (<a href="' + escapeHTML(data["urls"]["bundle_history"].toString()) + '" target="_blank">' + localized_strings.info + '</a>)';
+							}
+
+							if (line1 && line2) {
+								$("#es_price_loading_" + id).remove();
+								$("#es_price_" + id).append(line1 + "<br>" + line2 + line3);
+								$("#es_line_chart_" + id).css("top", (($("#es_price_" + id).outerHeight() - 20) / 2) + "px");
+								return;
+							}
+
+							if (line2) {
+								$("#es_price_loading_" + id).remove();
+								$("#es_price_" + id).append(line2 + line3);
+								$("#es_line_chart_" + id).css("top", (($("#es_price_" + id).outerHeight() - 20) / 2) + "px");
+								return;	
+							}
+
+							if (data["lowest"] === null && data["price"] === null) {					
+								$("#es_price_loading_" + id).remove();
+								$("#es_price_" + id).append(localized_strings.no_results_found);
+								return;
 							}
 						}
+					});
+				}
 
-						// "Historical Low"
-						if (data["lowest"]) {
-							if (settings.override_price != "auto") {
-								currencyConversion.load().done(function() {
-									lowesth = currencyConversion.convert(data["lowest"]["price"], data[".meta"]["currency"], settings.override_price);
-									currency_type = settings.override_price;
-								});
-							} else {
-								lowesth = data["lowest"]["price"].toString();
-							}
-							recorded = new Date(data["lowest"]["recorded"]*1000);
-							line2 = localized_strings.historical_low + ': ' + localized_strings.historical_low_format.replace("__price__", formatCurrency(lowesth, currency_type)).replace("__store__", escapeHTML(data["lowest"]["store"].toString())).replace("__date__", recorded.toLocaleDateString()) + ' (<a href="' + escapeHTML(data["urls"]["history"].toString()) + '" target="_blank">' + localized_strings.info + '</a>)';
-						}
-
-						// "Number of times this game has been in a bundle"
-						if (data["bundles"]["count"] > 0) {
-							line3 = "<br>" + localized_strings.bundle.bundle_count + ": " + data["bundles"]["count"] + ' (<a href="' + escapeHTML(data["urls"]["bundle_history"].toString()) + '" target="_blank">' + localized_strings.info + '</a>)';
-						}
-
-						if (line1 && line2) {
-							$("#es_price_loading_" + id).remove();
-							$("#es_price_" + id).append(line1 + "<br>" + line2 + line3);
-							$("#es_line_chart_" + id).css("top", (($("#es_price_" + id).outerHeight() - 20) / 2) + "px");
-							return;
-						}
-
-						if (line2) {
-							$("#es_price_loading_" + id).remove();
-							$("#es_price_" + id).append(line2 + line3);
-							$("#es_line_chart_" + id).css("top", (($("#es_price_" + id).outerHeight() - 20) / 2) + "px");
-							return;	
-						}
-
-						if (data["lowest"] === null && data["price"] === null) {					
-							$("#es_price_loading_" + id).remove();
-							$("#es_price_" + id).append(localized_strings.no_results_found);
-							return;
-						}
+				var timeoutId;
+				$(".wishlistRow").hover(function() {
+					var node = $(this);
+					var appid = node[0].id.replace("game_", "");
+					if (!timeoutId) {
+						timeoutId = window.setTimeout(function() {					
+							timeoutId = null;						
+							if ($("#es_price_" + appid).length == 0) {							
+								get_price_data("app", node, appid);
+							}	
+						}, 1000);
+					}
+				},
+				function() {
+					if (timeoutId) {
+						window.clearTimeout(timeoutId);
+						timeoutId = null;
 					}
 				});
 			}
-
-			var timeoutId;
-			$(".wishlistRow").hover(function() {
-				var node = $(this);
-				var appid = node[0].id.replace("game_", "");
-				if (!timeoutId) {
-					timeoutId = window.setTimeout(function() {					
-						timeoutId = null;						
-						if ($("#es_price_" + appid).length == 0) {							
-							get_price_data("app", node, appid);
-						}	
-					}, 1000);
-				}
-			},
-			function() {
-				if (timeoutId) {
-					window.clearTimeout(timeoutId);
-					timeoutId = null;
-				}
-			});
 		}
 	});
 }
@@ -2322,205 +2332,214 @@ function show_pricing_history(appid, type) {
 		if (settings.showlowestpricecoupon === undefined) { settings.showlowestpricecoupon = true; storage.set({'showlowestpricecoupon': settings.showlowestpricecoupon}); }
 		if (settings.showlowestprice_region === undefined) { settings.showlowestprice_region = "us"; storage.set({'showlowestprice_region': settings.showlowestprice_region}); }
 		if (settings.showallstores === undefined) { settings.showallstores = true; storage.set({'showallstores': settings.showallstores}); }
-		if (settings.stores === undefined) { settings.stores = [true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true]; storage.set({'stores': settings.stores}); }
+		if (settings.stores === undefined || settings.stores instanceof Array) {
+			settings.stores = {
+				"steam": true,
+				"amazonus": true,
+				"impulse": true,
+				"gamersgate": true,
+				"greenmangaming": true,
+				"direct2drive": true,
+				"origin": true,
+				"uplay": true,
+				"indiegalastore": true,
+				"gamesplanet": true,
+				"indiegamestand": true,
+				"gog": true,
+				"dotemu": true,
+				"nuuvem": true,
+				"dlgamer": true,
+				"humblestore": true,
+				"squenix": true,
+				"bundlestars": true,
+				"fireflower": true,
+				"humblewidgets": true,
+				"newegg": true,
+				"gamesrepublic": true,
+				"coinplay": true,
+				"funstock": true,
+				"wingamestore": true,
+				"gamebillet": true,
+				"silagames": true,
+				"playfield": true,
+				"imperialgames": true
+			};
+			storage.set({'stores': settings.stores});
+		}
+
 		if (settings.showlowestprice) {
-
-			// Get list of stores we're searching for
 			var storestring = "";
-			if (settings.stores[0]) { storestring += "steam,"; }
-			if (settings.stores[1]) { storestring += "amazonus,"; }
-			if (settings.stores[2]) { storestring += "impulse,"; }
-			if (settings.stores[3]) { storestring += "gamersgate,"; }
-			if (settings.stores[4]) { storestring += "greenmangaming,"; }
-			if (settings.stores[5]) { storestring += "direct2drive,"; }
-			if (settings.stores[6]) { storestring += "origin,"; }
-			if (settings.stores[7]) { storestring += "uplay,"; }
-			if (settings.stores[8]) { storestring += "indiegalastore,"; }
-			if (settings.stores[10]) { storestring += "gamesplanet,"; }
-			if (settings.stores[13]) { storestring += "gog,"; }
-			if (settings.stores[14]) { storestring += "dotemu,"; }
-			if (settings.stores[17]) { storestring += "nuuvem,"; }
-			if (settings.stores[19]) { storestring += "dlgamer,"; }
-			if (settings.stores[20]) { storestring += "humblestore,"; }
-			if (settings.stores[21]) { storestring += "indiegamestand,"; }
-			if (settings.stores[22]) { storestring += "squenix,"; }
-			if (settings.stores[23]) { storestring += "bundlestars,"; }
-			if (settings.stores[24]) { storestring += "fireflower,"; }
-			if (settings.stores[25]) { storestring += "humblewidgets,"; }
-			if (settings.stores[26]) { storestring += "newegg,"; }
-			if (settings.stores[27]) { storestring += "gamesrepublic,"; }
-			if (settings.stores[28]) { storestring += "coinplay,"; }
-			if (settings.stores[29]) { storestring += "funstock,"; }
-			if (settings.stores[30]) { storestring += "wingamestore,"; }
-			if (settings.stores[31]) { storestring += "gamebillet,"; }
-			if (settings.stores[32]) { storestring += "silagames,"; }
-			if (settings.stores[33]) { storestring += "playfield,"; }
-			if (settings.stores[34]) { storestring += "imperialgames,"; }
-			if (settings.showallstores) { storestring = "steam,amazonus,impulse,gamersgate,greenmangaming,direct2drive,origin,uplay,indiegalastore,gamesplanet,gog,dotemu,nuuvem,dlgamer,humblestore,squenix,bundlestars,fireflower,humblewidgets,newegg,gamesrepublic,coinplay,funstock,wingamestore,gamebillet,silagames,playfield,imperialgames"; }
-
-			// Get country code from Steam cookie
-			var cc = getStoreRegionCountryCode();
-
-			// Get all of the subIDs on the page
-			var subids = "";
-			$("input[name=subid]").each(function(index, value) {
-				subids += value.value + ",";
+			$.each(settings.stores, function(store, value) {
+				if (settings.stores[store] === true || settings.showallstores) {
+					storestring += store + ",";
+				}
 			});
 
-			get_http("//api.enhancedsteam.com/pricev3/?subs=" + subids + "&stores=" + storestring + "&cc=" + cc + "&appid=" + appid + "&coupon=" + settings.showlowestpricecoupon, function (txt) {
-				var price_data = JSON.parse(txt);
-				if (price_data) {
-					var bundles = [];
-					var currency_type = price_data[".meta"]["currency"];
-					$.each(price_data, function(key, data) {
-						if (key != ".cached" && key != ".meta" && data) {
-							var subid = key.replace("sub/", "");
-							var activates = "", line1 = "", line2 = "", line3 = "", html, recorded, lowest, lowesth;
-							var node = $("input[name=subid][value=" + subid + "]").parent().parent();
+			if (storestring !== "") {
+				// Get country code from Steam cookie
+				var cc = getStoreRegionCountryCode();
 
-							// "Lowest Price"
-							if (data["price"]) {
-								if (data["price"]["drm"] == "steam") {
-									activates = "(<b>" + localized_strings.activates + "</b>)";
-									if (data["price"]["store"] == "Steam") {
-										activates = "";
-									}
-								}
+				// Get all of the subIDs on the page
+				var subids = "";
+				$("input[name=subid]").each(function(index, value) {
+					subids += value.value + ",";
+				});
 
-								if (settings.override_price != "auto") {
-									currencyConversion.load().done(function() {
-										lowest = currencyConversion.convert(data["price"]["price"], price_data[".meta"]["currency"], settings.override_price);
-										currency_type = settings.override_price;
-									});
-								} else {
-									lowest = data["price"]["price"].toString();
-								}
+				get_http("//api.enhancedsteam.com/pricev3/?subs=" + subids + "&stores=" + storestring + "&cc=" + cc + "&appid=" + appid + "&coupon=" + settings.showlowestpricecoupon, function (txt) {
+					var price_data = JSON.parse(txt);
+					if (price_data) {
+						var bundles = [];
+						var currency_type = price_data[".meta"]["currency"];
+						$.each(price_data, function(key, data) {
+							if (key != ".cached" && key != ".meta" && data) {
+								var subid = key.replace("sub/", "");
+								var activates = "", line1 = "", line2 = "", line3 = "", html, recorded, lowest, lowesth;
+								var node = $("input[name=subid][value=" + subid + "]").parent().parent();
 
-								line1 = localized_strings.lowest_price + ': ' + localized_strings.lowest_price_format.replace("__price__", formatCurrency(lowest, currency_type)).replace("__store__", '<a href="' + escapeHTML(data["price"]["url"].toString()) + '" target="_blank">' + escapeHTML(data["price"]["store"].toString()) + '</a>') + ' ' + activates + ' (<a href="' + escapeHTML(data["urls"]["info"].toString()) + '" target="_blank">' + localized_strings.info + '</a>)';
-								if (settings.showlowestpricecoupon) {
-									if (data["price"]["price_voucher"]) {
-										line1 = localized_strings.lowest_price + ': ' + localized_strings.lowest_price_format.replace("__price__", formatCurrency(lowest, currency_type)).replace("__store__", '<a href="' + escapeHTML(data["price"]["url"].toString()) + '" target="_blank">' + escapeHTML(data["price"]["store"].toString()) + '</a>') + ' ' + localized_strings.after_coupon + ' <b>' + escapeHTML(data["price"]["voucher"].toString()) + '</b> ' + activates + ' (<a href="' + escapeHTML(data["urls"]["info"].toString()) + '" target="_blank">' + localized_strings.info + '</a>)';
-									}
-								}
-							}
-
-							// "Historical Low"
-							if (data["lowest"]) {
-								if (settings.override_price != "auto") {
-									currencyConversion.load().done(function() {
-										lowesth = currencyConversion.convert(data["lowest"]["price"], price_data[".meta"]["currency"], settings.override_price);
-										currency_type = settings.override_price;
-									});
-								} else {
-									lowesth = data["lowest"]["price"].toString();
-								}
-
-								recorded = new Date(data["lowest"]["recorded"]*1000);
-								line2 = localized_strings.historical_low + ': ' + localized_strings.historical_low_format.replace("__price__", formatCurrency(lowesth, currency_type)).replace("__store__", escapeHTML(data["lowest"]["store"].toString())).replace("__date__", recorded.toLocaleDateString()) + ' (<a href="' + escapeHTML(data["urls"]["history"].toString()) + '" target="_blank">' + localized_strings.info + '</a>)';
-							}
-
-							html = "<div class='es_lowest_price' id='es_price_" + subid + "'><div class='gift_icon' id='es_line_chart_" + subid + "'><img src='" + chrome.extension.getURL("img/line_chart.png") + "'></div>";
-
-							// "Number of times this game has been in a bundle"
-							if (data["bundles"]["count"] > 0) {
-								line3 = "<br>" + localized_strings.bundle.bundle_count + ": " + data["bundles"]["count"] + ' (<a href="' + escapeHTML(data["urls"]["bundles"].toString()) + '" target="_blank">' + localized_strings.info + '</a>)';
-							}
-
-							if (line1 && line2) {
-								$(node).before(html + line1 + "<br>" + line2 + line3);
-								$("#es_line_chart_" + subid).css("top", (($("#es_price_" + subid).outerHeight() - 20) / 2) + "px");
-							}
-
-							if (data["bundles"]["live"].length > 0) {
-								var length = data["bundles"]["live"].length;
-								for (var i = 0; i < length; i++) {
-									var enddate;
-									if (data["bundles"]["live"][i]["expiry"]) {
-										enddate = new Date(data["bundles"]["live"][i]["expiry"]*1000);
-									}
-									var currentdate = new Date().getTime();
-									if (!enddate || currentdate < enddate) {
-										var bundle = data["bundles"]["live"][i];
-										var bundle_normalized = JSON.stringify({
-											page:  bundle.page || "",
-											title: bundle.title || "",
-											url:   bundle.url || "",
-											tiers: (function() {
-												var tiers = [];
-												for (var tier in bundle.tiers) {
-													tiers.push((bundle.tiers[tier].games || []).sort());
-												}
-												return tiers;
-											})()
-										});
-										if (bundles.indexOf(bundle_normalized) < 0) {
-											bundles.push(bundle_normalized);
-										} else {
-											continue;
+								// "Lowest Price"
+								if (data["price"]) {
+									if (data["price"]["drm"] == "steam") {
+										activates = "(<b>" + localized_strings.activates + "</b>)";
+										if (data["price"]["store"] == "Steam") {
+											activates = "";
 										}
-										if (data["bundles"]["live"][i]["page"]) { purchase = '<div class="game_area_purchase_game"><div class="game_area_purchase_platform"></div><h1>' + localized_strings.buy_package.replace(/__package__/, data["bundles"]["live"][i]["page"] + ' ' + data["bundles"]["live"][i]["title"]) + '</h1>'; }
-										else { purchase = '<div class="game_area_purchase_game_wrapper"><div class="game_area_purchase_game"><div class="game_area_purchase_platform"></div><h1>' + localized_strings.buy_package.replace(/__package__/, data["bundles"]["live"][i]["title"]) + '</h1>'; }
-										if (enddate) purchase += '<p class="game_purchase_discount_countdown">' + localized_strings.bundle.offer_ends + ' ' + enddate + '</p>';
-										purchase += '<p class="package_contents">';
-										var tier_num = 1,
-											bundle_price,
-											app_name = $(".apphub_AppName").text();
-										$.each(data["bundles"]["live"][i]["tiers"], function(index, value) {
-											purchase += '<b>';
-											if (Object.keys(data["bundles"]["live"][i]["tiers"]).length > 1) {
-												var tier_name = value.note || localized_strings.bundle.tier.replace("__num__", tier_num);
-												var tier_price = value.price;
+									}
+
+									if (settings.override_price != "auto") {
+										currencyConversion.load().done(function() {
+											lowest = currencyConversion.convert(data["price"]["price"], price_data[".meta"]["currency"], settings.override_price);
+											currency_type = settings.override_price;
+										});
+									} else {
+										lowest = data["price"]["price"].toString();
+									}
+
+									line1 = localized_strings.lowest_price + ': ' + localized_strings.lowest_price_format.replace("__price__", formatCurrency(lowest, currency_type)).replace("__store__", '<a href="' + escapeHTML(data["price"]["url"].toString()) + '" target="_blank">' + escapeHTML(data["price"]["store"].toString()) + '</a>') + ' ' + activates + ' (<a href="' + escapeHTML(data["urls"]["info"].toString()) + '" target="_blank">' + localized_strings.info + '</a>)';
+									if (settings.showlowestpricecoupon) {
+										if (data["price"]["price_voucher"]) {
+											line1 = localized_strings.lowest_price + ': ' + localized_strings.lowest_price_format.replace("__price__", formatCurrency(lowest, currency_type)).replace("__store__", '<a href="' + escapeHTML(data["price"]["url"].toString()) + '" target="_blank">' + escapeHTML(data["price"]["store"].toString()) + '</a>') + ' ' + localized_strings.after_coupon + ' <b>' + escapeHTML(data["price"]["voucher"].toString()) + '</b> ' + activates + ' (<a href="' + escapeHTML(data["urls"]["info"].toString()) + '" target="_blank">' + localized_strings.info + '</a>)';
+										}
+									}
+								}
+
+								// "Historical Low"
+								if (data["lowest"]) {
+									if (settings.override_price != "auto") {
+										currencyConversion.load().done(function() {
+											lowesth = currencyConversion.convert(data["lowest"]["price"], price_data[".meta"]["currency"], settings.override_price);
+											currency_type = settings.override_price;
+										});
+									} else {
+										lowesth = data["lowest"]["price"].toString();
+									}
+
+									recorded = new Date(data["lowest"]["recorded"]*1000);
+									line2 = localized_strings.historical_low + ': ' + localized_strings.historical_low_format.replace("__price__", formatCurrency(lowesth, currency_type)).replace("__store__", escapeHTML(data["lowest"]["store"].toString())).replace("__date__", recorded.toLocaleDateString()) + ' (<a href="' + escapeHTML(data["urls"]["history"].toString()) + '" target="_blank">' + localized_strings.info + '</a>)';
+								}
+
+								html = "<div class='es_lowest_price' id='es_price_" + subid + "'><div class='gift_icon' id='es_line_chart_" + subid + "'><img src='" + chrome.extension.getURL("img/line_chart.png") + "'></div>";
+
+								// "Number of times this game has been in a bundle"
+								if (data["bundles"]["count"] > 0) {
+									line3 = "<br>" + localized_strings.bundle.bundle_count + ": " + data["bundles"]["count"] + ' (<a href="' + escapeHTML(data["urls"]["bundles"].toString()) + '" target="_blank">' + localized_strings.info + '</a>)';
+								}
+
+								if (line1 && line2) {
+									$(node).before(html + line1 + "<br>" + line2 + line3);
+									$("#es_line_chart_" + subid).css("top", (($("#es_price_" + subid).outerHeight() - 20) / 2) + "px");
+								}
+
+								if (data["bundles"]["live"].length > 0) {
+									var length = data["bundles"]["live"].length;
+									for (var i = 0; i < length; i++) {
+										var enddate;
+										if (data["bundles"]["live"][i]["expiry"]) {
+											enddate = new Date(data["bundles"]["live"][i]["expiry"]*1000);
+										}
+										var currentdate = new Date().getTime();
+										if (!enddate || currentdate < enddate) {
+											var bundle = data["bundles"]["live"][i];
+											var bundle_normalized = JSON.stringify({
+												page:  bundle.page || "",
+												title: bundle.title || "",
+												url:   bundle.url || "",
+												tiers: (function() {
+													var tiers = [];
+													for (var tier in bundle.tiers) {
+														tiers.push((bundle.tiers[tier].games || []).sort());
+													}
+													return tiers;
+												})()
+											});
+											if (bundles.indexOf(bundle_normalized) < 0) {
+												bundles.push(bundle_normalized);
+											} else {
+												continue;
+											}
+											if (data["bundles"]["live"][i]["page"]) { purchase = '<div class="game_area_purchase_game"><div class="game_area_purchase_platform"></div><h1>' + localized_strings.buy_package.replace(/__package__/, data["bundles"]["live"][i]["page"] + ' ' + data["bundles"]["live"][i]["title"]) + '</h1>'; }
+											else { purchase = '<div class="game_area_purchase_game_wrapper"><div class="game_area_purchase_game"><div class="game_area_purchase_platform"></div><h1>' + localized_strings.buy_package.replace(/__package__/, data["bundles"]["live"][i]["title"]) + '</h1>'; }
+											if (enddate) purchase += '<p class="game_purchase_discount_countdown">' + localized_strings.bundle.offer_ends + ' ' + enddate + '</p>';
+											purchase += '<p class="package_contents">';
+											var tier_num = 1,
+												bundle_price,
+												app_name = $(".apphub_AppName").text();
+											$.each(data["bundles"]["live"][i]["tiers"], function(index, value) {
+												purchase += '<b>';
+												if (Object.keys(data["bundles"]["live"][i]["tiers"]).length > 1) {
+													var tier_name = value.note || localized_strings.bundle.tier.replace("__num__", tier_num);
+													var tier_price = value.price;
+													if (settings.override_price != "auto") {
+														currencyConversion.load().done(function() {
+															tier_price = currencyConversion.convert(value.price, price_data[".meta"]["currency"], settings.override_price);
+															currency_type = settings.override_price;
+														});
+													}
+													tier_price = formatCurrency(tier_price, currency_type);
+													purchase += localized_strings.bundle.tier_includes.replace("__tier__", tier_name).replace("__price__", tier_price).replace("__num__", value.games.length);
+												} else {
+													purchase += localized_strings.bundle.includes.replace(/\(?__num__\)?/, value.games.length);
+												}
+												purchase += ':</b> ';
+												$.each(value["games"], function(game_index, game_value) {
+													if (game_value == app_name) { bundle_price = value["price"]; purchase += "<u>" + game_value + "</u>, "; }
+													else { purchase += game_value + ", "; }
+												});
+												purchase = purchase.replace(/, $/, "");
+												purchase += "<br>";
+												tier_num += 1;
+											});
+											purchase += '</p><div class="game_purchase_action"><div class="game_purchase_action_bg"><div class="btn_addtocart btn_packageinfo"><a class="btnv6_blue_blue_innerfade btn_medium" href="' + data["bundles"]["live"][i]["details"] + '" target="_blank"><span>' + localized_strings.bundle.info + '</span></a></div></div><div class="game_purchase_action_bg">';
+											if (bundle_price && bundle_price > 0) {
 												if (settings.override_price != "auto") {
 													currencyConversion.load().done(function() {
-														tier_price = currencyConversion.convert(value.price, price_data[".meta"]["currency"], settings.override_price);
+														bundle_price = currencyConversion.convert(bundle_price, price_data[".meta"]["currency"], settings.override_price);
 														currency_type = settings.override_price;
 													});
 												}
-												tier_price = formatCurrency(tier_price, currency_type);
-												purchase += localized_strings.bundle.tier_includes.replace("__tier__", tier_name).replace("__price__", tier_price).replace("__num__", value.games.length);
-											} else {
-												purchase += localized_strings.bundle.includes.replace(/\(?__num__\)?/, value.games.length);
+												if (data["bundles"]["live"][i]["pwyw"]) {
+													purchase += '<div class="es_each_box" itemprop="price">';
+													purchase += '<div class="es_each">' + localized_strings.bundle.at_least + '</div><div class="es_each_price" style="text-align: right;">' + formatCurrency(bundle_price, currency_type) + '</div>';
+												} else {
+													purchase += '<div class="game_purchase_price price" itemprop="price">';
+													purchase += formatCurrency(bundle_price, currency_type);
+												}
+												purchase += '</div>';
 											}
-											purchase += ':</b> ';
-											$.each(value["games"], function(game_index, game_value) {
-												if (game_value == app_name) { bundle_price = value["price"]; purchase += "<u>" + game_value + "</u>, "; }
-												else { purchase += game_value + ", "; }
-											});
-											purchase = purchase.replace(/, $/, "");
-											purchase += "<br>";
-											tier_num += 1;
-										});
-										purchase += '</p><div class="game_purchase_action"><div class="game_purchase_action_bg"><div class="btn_addtocart btn_packageinfo"><a class="btnv6_blue_blue_innerfade btn_medium" href="' + data["bundles"]["live"][i]["details"] + '" target="_blank"><span>' + localized_strings.bundle.info + '</span></a></div></div><div class="game_purchase_action_bg">';
-										if (bundle_price && bundle_price > 0) {
-											if (settings.override_price != "auto") {
-												currencyConversion.load().done(function() {
-													bundle_price = currencyConversion.convert(bundle_price, price_data[".meta"]["currency"], settings.override_price);
-													currency_type = settings.override_price;
-												});
-											}
-											if (data["bundles"]["live"][i]["pwyw"]) {
-												purchase += '<div class="es_each_box" itemprop="price">';
-												purchase += '<div class="es_each">' + localized_strings.bundle.at_least + '</div><div class="es_each_price" style="text-align: right;">' + formatCurrency(bundle_price, currency_type) + '</div>';
-											} else {
-												purchase += '<div class="game_purchase_price price" itemprop="price">';
-												purchase += formatCurrency(bundle_price, currency_type);
-											}
-											purchase += '</div>';
+											purchase += '<div class="btn_addtocart">';
+											purchase += '<a class="btnv6_green_white_innerfade btn_medium" href="' + data["bundles"]["live"][i]["url"] + '" target="_blank">';
+											purchase += '<span>' + localized_strings.buy + '</span>';
+											purchase += '</a></div></div></div></div>';
+											$("#game_area_purchase").after(purchase);
+											
+											$("#game_area_purchase").after("<h2 class='gradientbg'>" + localized_strings.bundle.header + " <img src='//cdn3.store.steampowered.com/public/images/v5/ico_external_link.gif' border='0' align='bottom'></h2>");
 										}
-										purchase += '<div class="btn_addtocart">';
-										purchase += '<a class="btnv6_green_white_innerfade btn_medium" href="' + data["bundles"]["live"][i]["url"] + '" target="_blank">';
-										purchase += '<span>' + localized_strings.buy + '</span>';
-										purchase += '</a></div></div></div></div>';
-										$("#game_area_purchase").after(purchase);
-										
-										$("#game_area_purchase").after("<h2 class='gradientbg'>" + localized_strings.bundle.header + " <img src='//cdn3.store.steampowered.com/public/images/v5/ico_external_link.gif' border='0' align='bottom'></h2>");
 									}
 								}
 							}
-						}
-					});
-				}
-			});
+						});
+					}
+				});
+			}
 		}
 	});
 }
@@ -5473,18 +5492,23 @@ function add_astats_link(appid) {
 }
 
 function add_achievement_completion_bar(appid) {
-	$(".myactivity_block").find(".details_block:first").after("<link href='http://steamcommunity-a.akamaihd.net/public/css/skin_1/playerstats_generic.css' rel='stylesheet' type='text/css'><div id='es_ach_stats' style='margin-bottom: 9px; margin-top: -16px; float: right;'></div>");
-	$("#es_ach_stats").load("//steamcommunity.com/my/stats/" + appid + "/ #topSummaryAchievements", function(response, status, xhr) {				
-		if (response.match(/achieveBarFull\.gif/)) {
-			var BarFull = $("#es_ach_stats").html().match(/achieveBarFull\.gif" width="([0-9]|[1-9][0-9]|[1-9][0-9][0-9])"/)[1];
-			var BarEmpty = $("#es_ach_stats").html().match(/achieveBarEmpty\.gif" width="([0-9]|[1-9][0-9]|[1-9][0-9][0-9])"/)[1];
-			BarFull = BarFull * .88;
-			BarEmpty = BarEmpty * .88;
-			var html = $("#es_ach_stats").html();
-			html = html.replace(/achieveBarFull\.gif" width="([0-9]|[1-9][0-9]|[1-9][0-9][0-9])"/, "achieveBarFull.gif\" width=\"" + escapeHTML(BarFull.toString()) + "\"");
-			html = html.replace(/achieveBarEmpty\.gif" width="([0-9]|[1-9][0-9]|[1-9][0-9][0-9])"/, "achieveBarEmpty.gif\" width=\"" + escapeHTML(BarEmpty.toString()) + "\"");
-			html = html.replace("::", ":");
-			$("#es_ach_stats").html(html);
+	storage.get(function(settings) {
+		if (settings.showachinstore === undefined) { settings.showachinstore = true; storage.set({'showachinstore': settings.showachinstore}); }
+		if (settings.showachinstore) {
+			$(".myactivity_block").find(".details_block:first").after("<link href='http://steamcommunity-a.akamaihd.net/public/css/skin_1/playerstats_generic.css' rel='stylesheet' type='text/css'><div id='es_ach_stats' style='margin-bottom: 9px; margin-top: -16px; float: right;'></div>");
+			$("#es_ach_stats").load("//steamcommunity.com/my/stats/" + appid + "/ #topSummaryAchievements", function(response, status, xhr) {				
+				if (response.match(/achieveBarFull\.gif/)) {
+					var BarFull = $("#es_ach_stats").html().match(/achieveBarFull\.gif" width="([0-9]|[1-9][0-9]|[1-9][0-9][0-9])"/)[1];
+					var BarEmpty = $("#es_ach_stats").html().match(/achieveBarEmpty\.gif" width="([0-9]|[1-9][0-9]|[1-9][0-9][0-9])"/)[1];
+					BarFull = BarFull * .88;
+					BarEmpty = BarEmpty * .88;
+					var html = $("#es_ach_stats").html();
+					html = html.replace(/achieveBarFull\.gif" width="([0-9]|[1-9][0-9]|[1-9][0-9][0-9])"/, "achieveBarFull.gif\" width=\"" + escapeHTML(BarFull.toString()) + "\"");
+					html = html.replace(/achieveBarEmpty\.gif" width="([0-9]|[1-9][0-9]|[1-9][0-9][0-9])"/, "achieveBarEmpty.gif\" width=\"" + escapeHTML(BarEmpty.toString()) + "\"");
+					html = html.replace("::", ":");
+					$("#es_ach_stats").html(html);
+				}
+			});
 		}
 	});
 }

--- a/js/options.js
+++ b/js/options.js
@@ -10,362 +10,168 @@ var highlight_defaults = {
 	"notinterested": "#4f4f4f"
 }
 
-// Saves options to localStorage.
+var settings_defaults = {
+	"language": "eng",
+	"highlight_owned_color": highlight_defaults.owned,
+	"highlight_wishlist_color": highlight_defaults.wishlist,
+	"highlight_coupon_color": highlight_defaults.coupon,
+	"highlight_inv_gift_color": highlight_defaults.inv_gift,
+	"highlight_inv_guestpass_color": highlight_defaults.inv_guestpass,
+	"highlight_notinterested_color": highlight_defaults.notinterested,
+
+	"tag_owned_color": highlight_defaults.owned,
+	"tag_wishlist_color": highlight_defaults.wishlist,
+	"tag_coupon_color": highlight_defaults.coupon,
+	"tag_inv_gift_color": highlight_defaults.inv_gift,
+	"tag_inv_guestpass_color": highlight_defaults.inv_guestpass,
+	"tag_notinterested_color": highlight_defaults.notinterested,
+
+	"highlight_owned": true,
+	"highlight_wishlist": true,
+	"highlight_coupon": false,
+	"highlight_inv_gift": false,
+	"highlight_inv_guestpass": false,
+	"highlight_notinterested": false,
+	"highlight_excludef2p": false,
+
+	"tag_owned": false,
+	"tag_wishlist": false,
+	"tag_coupon": false,
+	"tag_inv_gift": false,
+	"tag_inv_guestpass": false,
+	"tag_notinterested": true,
+	"tag_short": false,
+
+	"hide_owned": false,
+	"hidetmsymbols": false,
+
+	"showlowestprice": true,
+	"showlowestprice_onwishlist": true,
+	"showlowestpricecoupon": true,
+	"showallstores": true,
+	"stores": [true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true],
+	"override_price": "auto",
+	"showregionalprice": "mouse",
+	"regional_countries": ["us", "gb", "eu1", "ru", "br", "au", "jp"],
+
+	"showtotal": true,
+	"showmarkettotal": true,
+	"showsteamrepapi": true,
+	"showmcus": true,
+	"showhltb": true,
+	"showpcgw": true,
+	"showclient": true,
+	"showsteamcardexchange": false,
+	"showsteamdb": true,
+	"showastatslink": true,
+	"showwsgf": true,
+	"show_package_info": false,
+	"show_sysreqcheck": false,
+	"show_steamchart_info": true,
+	"show_steamspy_info": true,
+	"show_carousel_descriptions": true,
+	"show_early_access": true,
+	"show_alternative_linux_icon": false,
+	"show_itad_button": false,
+	"skip_got_steam": false,
+	
+	"hideinstallsteambutton": false,
+	"hideaboutmenu": false,
+	"replaceaccountname": false,
+	"showfakeccwarning": true,
+	"showlanguagewarning": true,
+	"showlanguagewarninglanguage": "English",
+	"homepage_tab_selection": "remember",
+	"send_age_info": true,
+	"html5video": true,
+	"contscroll": true,
+	"showdrm": true,
+	"show_acrtag_info": false,
+	"regional_hideworld": false,
+	"showinvnav": false,
+	"showesbg": true,
+	"quickinv": true,
+	"quickinv_diff": -0.01,
+	"showallachievements": false,
+	"showcomparelinks": false,
+	"showgreenlightbanner": false,
+	"dynamicgreenlight": false,
+	"remembergreenlightfilter": false,
+	"endlessscrollinggreenlight": true,
+	"hideactivelistings": false,
+	"hidespamcomments": false,
+	"spamcommentregex": "[\\u2500-\\u25FF]",
+	"wlbuttoncommunityapp": true,
+	"removeguideslanguagefilter": false,
+	"disablelinkfilter": false,
+	"show1clickgoo": true,
+	"show_profile_link_images": "gray",
+	"profile_steamgifts": true,
+	"profile_steamrep": true,
+	"profile_steamdbcalc": true,
+	"profile_astats": true,
+	"profile_backpacktf": true,
+	"profile_astatsnl": true,
+	"profile_api_info": false, // not used?
+	"api_key": false, // not used?
+	"profile_permalink": true,
+	"steamcardexchange": true
+};
+
+// Saves options to localStorage
 function save_options() {
-	// Store Options
-	highlight_owned_color = $("#highlight_owned_color").val();
-	highlight_wishlist_color = $("#highlight_wishlist_color").val();
-	highlight_coupon_color = $("#highlight_coupon_color").val();
-	highlight_inv_gift_color = $("#highlight_inv_gift_color").val();
-	highlight_inv_guestpass_color = $("#highlight_inv_guestpass_color").val();
-	highlight_notinterested_color = $("#highlight_notinterested_color").val();
-
-	tag_owned_color = $("#tag_owned_color").val();
-	tag_owned_color = $("#tag_owned_color").val();
-	tag_wishlist_color = $("#tag_wishlist_color").val();
-	tag_coupon_color = $("#tag_coupon_color").val();
-	tag_inv_gift_color = $("#tag_inv_gift_color").val();
-	tag_inv_guestpass_color = $("#tag_inv_guestpass_color").val();
-	tag_notinterested_color = $("#tag_notinterested_color").val();
-
-	highlight_owned = $("#highlight_owned").prop('checked');
-	highlight_wishlist = $("#highlight_wishlist").prop('checked');
-	highlight_coupon = $("#highlight_coupon").prop('checked');
-	highlight_inv_gift = $("#highlight_inv_gift").prop('checked');
-	highlight_inv_guestpass = $("#highlight_inv_guestpass").prop('checked');
-	highlight_notinterested = $("#highlight_notinterested").prop('checked');
-	highlight_excludef2p = $("#highlight_excludef2p").prop('checked');
-
-	tag_owned = $("#tag_owned").prop('checked');
-	tag_wishlist = $("#tag_wishlist").prop('checked');
-	tag_coupon = $("#tag_coupon").prop('checked');
-	tag_inv_gift = $("#tag_inv_gift").prop('checked');
-	tag_inv_guestpass = $("#tag_inv_guestpass").prop('checked');
-	tag_notinterested = $("#tag_notinterested").prop('checked');
-	tag_short = $("#tag_short").prop('checked');
+	var saveSettings = {};
 	
-	hide_owned = $("#hide_owned").prop('checked');
-	hidetmsymbols = $("#hidetmsymbols").prop('checked');
+	$("[data-setting]").each(function(i, el) {
+		var setting = $(el).data("setting");
 
-	hideinstallsteambutton = $("#hideinstallsteambutton").prop('checked');
-	hideaboutmenu = $("#hideaboutmenu").prop('checked');
-	replaceaccountname = $("#replaceaccountname").prop('checked');
-	showfakeccwarning = $("#showfakeccwarning").prop('checked');
-	showlanguagewarning = $("#showlanguagewarning").prop('checked');
-	showlanguagewarninglanguage = $("#warning_language").val();
-	homepage_tab_selection = $("#homepage_tab_selection").val();
-	send_age_info = $("#send_age_info").prop('checked');
-	html5video = $("#html5video").prop('checked');
-	contscroll = $("#contscroll").prop('checked');
-	showdrm = $("#showdrm").prop('checked');
-	show_acrtag_info = $("#showacrtag").prop('checked');
-	showmcus = $("#showmcus").prop('checked');
-	showhltb = $("#showhltb").prop('checked');
-	showpcgw = $("#showpcgw").prop('checked');
-	showclient = $("#showclient").prop('checked');
-	showsteamcardexchange = $("#showsteamcardexchange").prop('checked');
-	showsteamdb = $("#showsteamdb").prop('checked');
-	showastatslink = $("#showastatslink").prop('checked');
-	showwsgf = $("#showwsgf").prop('checked');
-	show_package_info = $("#show_package_info").prop('checked');
-	show_sysreqcheck = $("#show_sysreqcheck").prop('checked');
-	show_steamchart_info = $("#show_steamchart_info").prop('checked');
-	show_steamspy_info = $("#show_steamspy_info").prop('checked');
-	show_carousel_descriptions = $("#show_carousel_descriptions").prop('checked');
-	show_early_access = $("#show_early_access").prop('checked');
-	show_alternative_linux_icon = $("#show_alternative_linux_icon").prop('checked');
-	show_itad_button = $("#show_itad_button").prop('checked');
-	skip_got_steam = $("#skip_got_steam").prop('checked');
-	
-	// Price Options
-	showlowestprice = $("#showlowestprice").prop('checked');
-	showlowestprice_onwishlist = $("#showlowestprice_onwishlist").prop('checked');
-	showlowestpricecoupon = $("#showlowestpricecoupon").prop('checked');
-	showallstores = $("#stores_all").prop('checked');
-	stores = [
-		$("#steam").prop('checked'),
-		$("#amazonus").prop('checked'),
-		$("#impulse").prop('checked'),
-		$("#gamersgate").prop('checked'),
-		$("#greenmangaming").prop('checked'),
-		$("#direct2drive").prop('checked'),
-		$("#origin").prop('checked'),
-		$("#uplay").prop('checked'),
-		$("#indiegalastore").prop('checked'),
-		true,
-		$("#gamesplanet").prop('checked'),
-		true,
-		true,
-		$("#gog").prop('checked'),
-		$("#dotemu").prop('checked'),
-		true,
-		true,
-		$("#nuuvem").prop('checked'),
-		true,
-		$("#dlgamer").prop('checked'),			
-		$("#humblestore").prop('checked'),
-		$("#indiegamestand").prop('checked'),
-		$("#squenix").prop('checked'),
-		$("#bundlestars").prop('checked'),
-		$("#fireflower").prop('checked'),
-		$("#humblewidgets").prop('checked'),
-		$("#newegg").prop('checked'),
-		$("#gamesrepublic").prop('checked'),
-		$("#coinplay").prop('checked'),
-		$("#funstock").prop('checked'),
-		$("#wingamestore").prop('checked'),
-		$("#gamebillet").prop('checked'),
-		$("#silagames").prop('checked'),
-		$("#playfield").prop('checked'),
-		$("#imperialgames").prop('checked')
-	];
-	override_price = $("#override_price").val();
-	showregionalprice = $("#regional_price_on").val();
-	regional_hideworld = $("#regional_hideworld").prop('checked');
-	regional_countries = $.map($('.regional_country'), function (el, i) {
+		if (settings_defaults.hasOwnProperty(setting)) {
+			if ($(el).is(":checkbox")) {
+				saveSettings[setting] = $(el).prop("checked");
+			} else {
+				saveSettings[setting] = $(el).val();
+			}
+		}
+	});
+
+	// Get checked stores, but only if loaded already from storage
+	if (!$("#stores_all").prop('checked') && $("#store_stores").hasClass("es_checks_loaded")) {
+		saveSettings.stores = $.map($("#store_stores").find("input[type='checkbox']"), function(el, i) {
+			return $(el).prop("checked");
+		});
+	}
+
+	if (!saveSettings.remembergreenlightfilter) {
+		saveSettings.remembergreenlightfilter = [];
+	}
+
+	saveSettings.regional_countries = $.map($('.regional_country'), function(el, i) {
 		return $(el).val();
 	});
-
-	for(var i = regional_countries.length - 1; i >= 0; i--) {
-	    if(regional_countries[i] === "") {
-	       regional_countries.splice(i, 1);
-	    }
+	// Remove empty countries
+	for (var i = saveSettings.regional_countries.length - 1; i >= 0; i--) {
+		if (saveSettings.regional_countries[i] === "") {
+			saveSettings.regional_countries.splice(i, 1);
+		}
 	}
 
-	// Community Options
-	showtotal = $("#showtotal").prop('checked');
-	showmarkettotal = $("#showmarkettotal").prop('checked');
-	showsteamrepapi = $("#showsteamrepapi").prop('checked');
-	showinvnav = $("#showinvnav").prop('checked');
-	showesbg = $("#showesbg").prop('checked');
-	quickinv = $("#quickinv").prop('checked');
-	quickinv_diff = parseFloat($("#quickinv_diff").val().trim()).toFixed(2);
-	showallachievements = $("#showallachievements").prop('checked');
-	showcomparelinks = $("#showcomparelinks").prop('checked');
-	showgreenlightbanner = $("#showgreenlightbanner").prop('checked');
-	dynamicgreenlight = $("#dynamicgreenlight").prop('checked');
-	remembergreenlightfilter = $("#remembergreenlightfilter").prop('checked');
-	endlessscrollinggreenlight = $("#endlessscrollinggreenlight").prop('checked');
-	hideactivelistings = $("#hideactivelistings").prop('checked');
-	hidespamcomments = $("#hidespamcomments").prop('checked');
-	spamcommentregex = $("#spamcommentregex").val().trim();
-	wlbuttoncommunityapp = $("#wlbuttoncommunityapp").prop('checked');
-	removeguideslanguagefilter = $("#removeguideslanguagefilter").prop('checked');
-	disablelinkfilter = $("#disablelinkfilter").prop('checked');
-	show1clickgoo = $("#show1clickgoo").prop('checked');
+	saveSettings.quickinv_diff = parseFloat(saveSettings.quickinv_diff.trim()).toFixed(2);
 
-	// Profile Link Options
-	profile_steamgifts = $("#profile_steamgifts").prop('checked');
-	profile_steamrep = $("#profile_steamrep").prop('checked');
-	profile_steamdbcalc = $("#profile_steamdbcalc").prop('checked');
-	profile_wastedonsteam = $("#profile_wastedonsteam").prop('checked');
-	profile_astats = $("#profile_astats").prop('checked');
-	profile_backpacktf = $("#profile_backpacktf").prop('checked');
-	profile_astatsnl = $("#profile_astatsnl").prop('checked');
-	profile_api_info = $("#profile_api_info").prop('checked');
-	api_key = $("#api_key").val();
-	profile_permalink = $("#profile_permalink").prop('checked');
-	show_profile_link_images = $("#profile_link_images_dropdown").val();
-	
-	steamcardexchange = $("#steamcardexchange").prop('checked');
+	storage.set(saveSettings);
 
-	storage.set({
-		'highlight_owned_color': highlight_owned_color,
-		'highlight_wishlist_color': highlight_wishlist_color,
-		'highlight_coupon_color': highlight_coupon_color,
-		'highlight_inv_gift_color': highlight_inv_gift_color,
-		'highlight_inv_guestpass_color': highlight_inv_guestpass_color,
-		'highlight_notinterested_color': highlight_notinterested_color,
-		'highlight_excludef2p': highlight_excludef2p,
-
-		'tag_owned_color': tag_owned_color,
-		'tag_wishlist_color': tag_wishlist_color,
-		'tag_coupon_color': tag_coupon_color,
-		'tag_inv_gift_color': tag_inv_gift_color,
-		'tag_inv_guestpass_color': tag_inv_guestpass_color,
-		'tag_notinterested_color': tag_notinterested_color,
-
-		'highlight_owned': highlight_owned,
-		'highlight_wishlist': highlight_wishlist,
-		'highlight_coupon': highlight_coupon,
-		'highlight_inv_gift': highlight_inv_gift,
-		'highlight_inv_guestpass': highlight_inv_guestpass,
-		'highlight_notinterested': highlight_notinterested,
-
-		'tag_owned': tag_owned,
-		'tag_wishlist': tag_wishlist,
-		'tag_coupon': tag_coupon,
-		'tag_inv_gift': tag_inv_gift,
-		'tag_inv_guestpass': tag_inv_guestpass,
-		'tag_notinterested': tag_notinterested,
-		'tag_short': tag_short,
-		
-		'hide_owned': hide_owned,
-		'hidetmsymbols': hidetmsymbols,
-
-		'hideinstallsteambutton': hideinstallsteambutton,
-		'hideaboutmenu': hideaboutmenu,
-		'replaceaccountname': replaceaccountname,
-		'showfakeccwarning': showfakeccwarning,
-		'showlanguagewarning': showlanguagewarning,
-		'showlanguagewarninglanguage': showlanguagewarninglanguage,
-		'homepage_tab_selection': homepage_tab_selection,
-		'send_age_info': send_age_info,
-		'html5video': html5video,
-		'contscroll': contscroll,
-		'showdrm': showdrm,
-		'show_acrtag_info': show_acrtag_info,
-		'showmcus': showmcus,
-		'showhltb': showhltb,
-		'showpcgw': showpcgw,
-		'showclient': showclient,
-		'showsteamcardexchange': showsteamcardexchange,
-		'showsteamdb': showsteamdb,
-		'showastatslink': showastatslink,
-		'showwsgf': showwsgf,
-		'show_package_info': show_package_info,
-		'show_sysreqcheck': show_sysreqcheck,
-		'show_steamchart_info': show_steamchart_info,
-		'show_steamspy_info': show_steamspy_info,
-		'show_carousel_descriptions': show_carousel_descriptions,
-		'show_early_access': show_early_access,
-		'show_alternative_linux_icon': show_alternative_linux_icon,
-		'show_itad_button': show_itad_button,
-		'skip_got_steam': skip_got_steam,
-		
-		'showlowestprice': showlowestprice,
-		'showlowestprice_onwishlist': showlowestprice_onwishlist,
-		'showlowestpricecoupon': showlowestpricecoupon,
-		'showallstores': showallstores,
-		'stores': stores,
-		'override_price': override_price,
-		'showregionalprice': showregionalprice,
-		'regional_hideworld': regional_hideworld,
-		'regional_countries': regional_countries,
-
-		'showtotal': showtotal,
-		'showmarkettotal': showmarkettotal,
-		'showsteamrepapi': showsteamrepapi,
-		'showinvnav': showinvnav,
-		'showesbg': showesbg,
-		'quickinv': quickinv,
-		'quickinv_diff': quickinv_diff,
-		'showallachievements': showallachievements,
-		'showcomparelinks': showcomparelinks,
-		'showgreenlightbanner': showgreenlightbanner,
-		'dynamicgreenlight': dynamicgreenlight,
-		'remembergreenlightfilter': remembergreenlightfilter,
-		'endlessscrollinggreenlight': endlessscrollinggreenlight,
-		'hideactivelistings': hideactivelistings,
-		'hidespamcomments': hidespamcomments,
-		'spamcommentregex': spamcommentregex,
-		'wlbuttoncommunityapp': wlbuttoncommunityapp,
-		'removeguideslanguagefilter': removeguideslanguagefilter,
-		'disablelinkfilter': disablelinkfilter,
-		'show1clickgoo': show1clickgoo,
-
-		'profile_steamgifts': profile_steamgifts,
-		'profile_steamrep': profile_steamrep,
-		'profile_steamdbcalc': profile_steamdbcalc,
-		'profile_astats': profile_astats,
-		'profile_backpacktf': profile_backpacktf,
-		'profile_astatsnl': profile_astatsnl,
-		'profile_api_info': profile_api_info,
-		'api_key': api_key,
-		'profile_permalink': profile_permalink,
-		'show_profile_link_images': show_profile_link_images,
-		
-		'steamcardexchange': steamcardexchange
-	});
-	if (!remembergreenlightfilter) {
-		storage.set({'greenlightfilteroptions': []});
-	}
-	$("#saved").stop(true,true).fadeIn().delay(600).fadeOut();
-}
-
-// toggles pages
-function load_store_tab() {
-	$(".content").hide();
-	$("#maincontent_store").show();	
-	$(".selected").removeClass("selected");
-	$("#nav_store").addClass("selected");
-}
-
-function load_price_tab() {
-	$(".content").hide();
-	$("#maincontent_price").show();	
-	$(".selected").removeClass("selected");
-	$("#nav_price").addClass("selected");
-}
-
-function load_community_tab() {
-	$(".content").hide();
-	$("#maincontent_community").show();
-	$(".selected").removeClass("selected");
-	$("#nav_community").addClass("selected");
-}
-
-function load_news_tab() {
-	$(".content").hide();	
-	$("#maincontent_news").show();
-	$(".selected").removeClass("selected");
-	$("#nav_news").addClass("selected");
-}
-
-function load_about_tab() {
-	$(".content").hide();
-	$("#maincontent_about").show();
-	$(".selected").removeClass("selected");
-	$("#nav_about").addClass("selected");
-}
-
-function load_credits_tab() {
-	$(".content").hide();	
-	$("#maincontent_credits").show();
-	$(".selected").removeClass("selected");
-	$("#nav_credits").addClass("selected");
+	$("#saved").stop(true, true).fadeIn().delay(600).fadeOut();
 }
 
 function toggle_stores() {
-	var all_stores = $("#stores_all").prop('checked');
-	switch (all_stores) {
-		case true: 
+	if ($("#stores_all").prop('checked')) {
 		$("#store_stores").hide();
-		break;
-		case false:
+	} else {
 		$("#store_stores").show();
 		storage.get(function(settings) {
-			$("#steam").prop('checked', settings.stores[0]);
-			$("#amazonus").prop('checked', settings.stores[1]);
-			$("#impulse").prop('checked', settings.stores[2]);
-			$("#gamersgate").prop('checked', settings.stores[3]);
-			$("#greenmangaming").prop('checked', settings.stores[4]);
-			$("#direct2drive").prop('checked', settings.stores[5]);
-			$("#origin").prop('checked', settings.stores[6]);
-			$("#uplay").prop('checked', settings.stores[7]);
-			$("#indiegalastore").prop('checked', settings.stores[8]);
-			$("#gamesplanet").prop('checked', settings.stores[10]);
-			$("#gog").prop('checked', settings.stores[13]);
-			$("#dotemu").prop('checked', settings.stores[14]);
-			$("#nuuvem").prop('checked', settings.stores[17]);
-			$("#dlgamer").prop('checked', settings.stores[19]);
-			$("#humblestore").prop('checked', settings.stores[20]);
-			$("#indiegamestand").prop('checked', settings.stores[21]);
-			$("#squenix").prop('checked', settings.stores[22]);
-			$("#bundlestars").prop('checked', settings.stores[23]);
-			$("#fireflower").prop('checked', settings.stores[24]);
-			$("#humblewidgets").prop('checked', settings.stores[25]);
-			$("#newegg").prop('checked', settings.stores[26]);
-			$("#gamesrepublic").prop('checked', settings.stores[27]);
-			$("#coinplay").prop('checked', settings.stores[28]);
-			$("#funstock").prop('checked', settings.stores[29]);
-			$("#wingamestore").prop('checked', settings.stores[30]);
-			$("#gamebillet").prop('checked', settings.stores[31]);
-			$("#silagames").prop('checked', settings.stores[32]);
-			$("#playfield").prop('checked', settings.stores[33]);
-			$("#imperialgames").prop('checked', settings.stores[34]);
+			$("#store_stores").addClass("es_checks_loaded").find("input[type='checkbox']").each(function(i, checkbox) {
+				$(checkbox).prop("checked", settings.stores[i]);
+			});
 		});
-		break;
 	}
 }
 
@@ -387,234 +193,53 @@ $.getJSON(chrome.extension.getURL('cc.json'), function (data) {
 // Restores select box state to saved value from SyncStorage.
 function load_options() {
 	storage.get(function(settings) {
+		// Loops over the default settings and if the setting can't be found in storage the default is set
+		function checkSettings(settings, settingsStrg) {
+			var data = {};
 
-		// Load default values for settings if they do not exist (and sync them to Chrome)
-		if (settings.language === undefined) { settings.language = "eng"; storage.set({'language': settings.language}); }
-		if (settings.highlight_owned_color === undefined) { settings.highlight_owned_color = highlight_defaults.owned; storage.set({'highlight_owned_color': settings.highlight_owned_color});	}
-		if (settings.highlight_wishlist_color === undefined) { settings.highlight_wishlist_color = highlight_defaults.wishlist; storage.set({'highlight_wishlist_color': settings.highlight_wishlist_color}); }
-		if (settings.highlight_coupon_color === undefined) { settings.highlight_coupon_color = highlight_defaults.coupon; storage.set({'highlight_coupon_color': settings.highlight_coupon_color}); }
-		if (settings.highlight_inv_gift_color === undefined) { settings.highlight_inv_gift_color = highlight_defaults.inv_gift; storage.set({'highlight_inv_gift_color': settings.highlight_inv_gift_color}); }
-		if (settings.highlight_inv_guestpass_color === undefined) { settings.highlight_inv_guestpass_color = highlight_defaults.inv_guestpass; storage.set({'highlight_inv_guestpass_color': settings.highlight_inv_guestpass_color}); }
-		if (settings.highlight_notinterested_color === undefined) { settings.highlight_notinterested_color = highlight_defaults.notinterested; storage.set({'highlight_notinterested_color': settings.highlight_notinterested_color}); }
+			$.each(settings, function(setting, defaultValue){
+				if (typeof settingsStrg[setting] === 'undefined') {
+					data[setting] = defaultValue;
 
-		if (settings.tag_owned_color === undefined) { settings.tag_owned_color = highlight_defaults.owned; storage.set({'tag_owned_color': settings.tag_owned_color}); }
-		if (settings.tag_wishlist_color === undefined) { settings.tag_wishlist_color = highlight_defaults.wishlist; storage.set({'tag_wishlist_color': settings.tag_wishlist_color}); }
-		if (settings.tag_coupon_color === undefined) { settings.tag_coupon_color = highlight_defaults.coupon; storage.set({'tag_coupon_color': settings.tag_coupon_color}); }
-		if (settings.tag_inv_gift_color === undefined) { settings.tag_inv_gift_color = highlight_defaults.inv_gift; storage.set({'tag_inv_gift_color': settings.tag_inv_gift_color}); }
-		if (settings.tag_inv_guestpass_color === undefined) { settings.tag_inv_guestpass_color = highlight_defaults.inv_guestpass; storage.set({'tag_inv_guestpass_color': settings.tag_inv_guestpass_color}); }
-		if (settings.tag_notinterested_color === undefined) { settings.tag_notinterested_color = highlight_defaults.notinterested; storage.set({'tag_notinterested_color': settings.tag_notinterested_color}); }
+					var tmpObj = {};
+					tmpObj[setting] = defaultValue;
+					storage.set(tmpObj);
+				} else {
+					data[setting] = settingsStrg[setting];
+				}
+			});
 
-		if (settings.highlight_owned === undefined) { settings.highlight_owned = true; storage.set({'highlight_owned': settings.highlight_owned}); }
-		if (settings.highlight_wishlist === undefined) { settings.highlight_wishlist = true; storage.set({'highlight_wishlist': settings.highlight_wishlist}); }
-		if (settings.highlight_coupon === undefined) { settings.highlight_coupon = false; storage.set({'highlight_coupon': settings.highlight_coupon}); }
-		if (settings.highlight_inv_gift === undefined) { settings.highlight_inv_gift = false; storage.set({'highlight_inv_gift': settings.highlight_inv_gift}); }
-		if (settings.highlight_inv_guestpass === undefined) { settings.highlight_inv_guestpass = false; storage.set({'highlight_inv_guestpass': settings.highlight_inv_guestpass}); }
-		if (settings.highlight_notinterested === undefined) { settings.highlight_notinterested = false; storage.set({'highlight_notinterested': settings.highlight_notinterested}); }
-		if (settings.highlight_excludef2p === undefined) { settings.highlight_excludef2p = false; storage.set({'highlight_excludef2p': settings.highlight_excludef2p}); }
+			return data;
+		}
 
-		if (settings.tag_owned === undefined) { settings.tag_owned = false; storage.set({'tag_owned': settings.tag_owned}); }
-		if (settings.tag_wishlist === undefined) { settings.tag_wishlist = false; storage.set({'tag_wishlist': settings.tag_wishlist}); }
-		if (settings.tag_coupon === undefined) { settings.tag_coupon = false; storage.set({'tag_coupon': settings.tag_coupon}); }
-		if (settings.tag_inv_gift === undefined) { settings.tag_inv_gift = false; storage.set({'tag_inv_gift': settings.tag_inv_gift}); }
-		if (settings.tag_inv_guestpass === undefined) { settings.tag_inv_guestpass = false; storage.set({'tag_inv_guestpass': settings.tag_inv_guestpass}); }
-		if (settings.tag_notinterested === undefined) { settings.tag_notinterested = true; storage.set({'tag_notinterested': settings.tag_notinterested}); }
-		if (settings.tag_short === undefined) { settings.tag_short = false; storage.set({'tag_short': settings.tag_short}); }
+		// Initiate settings against the defaults
+		settings = checkSettings(settings_defaults, settings);
 
-		if (settings.hide_owned === undefined) { settings.hide_owned = false; storage.set({'hide_owned': settings.hide_owned}); }
-		if (settings.hidetmsymbols === undefined) { settings.hidetmsymbols = false; storage.set({'hidetmsymbols': settings.hidetmsymbols}); }
+		// Set the value or state for each input
+		$("[data-setting]").each(function(){
+			var setting = $(this).data("setting");
 
-		if (settings.showlowestprice === undefined) { settings.showlowestprice = true; storage.set({'showlowestprice': settings.showlowestprice}); }
-		if (settings.showlowestprice_onwishlist === undefined) { settings.showlowestprice_onwishlist = true; storage.set({'showlowestprice_onwishlist': settings.showlowestprice_onwishlist}); }
-		if (settings.showlowestpricecoupon === undefined) { settings.showlowestpricecoupon = true; storage.set({'showlowestpricecoupon': settings.showlowestpricecoupon}); }
-		if (settings.showallstores === undefined) { settings.showallstores = true; storage.set({'showallstores': settings.showallstores}); }
-		if (settings.stores === undefined) { settings.stores = [true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true]; storage.set({'stores': settings.stores}); }
-		if (settings.override_price === undefined) { settings.override_price = "auto"; storage.set({'override_price': settings.override_price}); }
-		if (settings.showregionalprice === undefined) { settings.showregionalprice = "mouse"; storage.set({'showregionalprice': settings.showregionalprice}); }
-		if (settings.regional_countries === undefined) { settings.regional_countries = ["us", "gb", "eu1", "ru", "br", "au", "jp"]; storage.set({'regional_countries': settings.regional_countries}); }
+			if (settings_defaults.hasOwnProperty(setting)) {
+				if ($(this).is(":checkbox")) {
+					$(this).prop('checked', settings[setting]);
+				} else {
+					$(this).val(settings[setting]);
+				}
+			}
+		});
 
-		if (settings.showtotal === undefined) { settings.showtotal = true; storage.set({'showtotal': settings.showtotal}); }
-		if (settings.showmarkettotal === undefined) { settings.showmarkettotal = true; storage.set({'showmarkettotal': settings.showmarkettotal}); }
-		if (settings.showsteamrepapi === undefined) { settings.showsteamrepapi = true; storage.set({'showsteamrepapi': settings.showsteamrepapi}); }
-		if (settings.showmcus === undefined) { settings.showmcus = true; storage.set({'showmcus': settings.showmcus}); }
-		if (settings.showhltb === undefined) { settings.showhltb = true; storage.set({'showhltb': settings.showhltb}); }
-		if (settings.showpcgw === undefined) { settings.showpcgw = true; storage.set({'showpcgw': settings.showpcgw}); }
-		if (settings.showclient === undefined) { settings.showclient = true; storage.set({'showclient': settings.showclient}); }
-		if (settings.showsteamcardexchange === undefined) { settings.showsteamcardexchange = false; storage.set({'showsteamcardexchange': settings.showsteamcardexchange}); }
-		if (settings.showsteamdb === undefined) { settings.showsteamdb = true; storage.set({'showsteamdb': settings.showsteamdb}); }
-		if (settings.showastatslink === undefined) { settings.showastatslink = true; storage.set({'showastatslink': settings.showastatslink}); }
-		if (settings.showwsgf === undefined) { settings.showwsgf = true; storage.set({'showwsgf': settings.showwsgf}); }
-		if (settings.show_package_info === undefined) { settings.show_package_info = false; storage.set({'show_package_info': settings.show_package_info}); }
-		if (settings.show_sysreqcheck === undefined) { settings.show_sysreqcheck = false; storage.set({'show_sysreqcheck': settings.show_sysreqcheck}); }
-		if (settings.show_steamchart_info === undefined) { settings.show_steamchart_info = true; storage.set({'show_steamchart_info': settings.show_steamchart_info}); }
-		if (settings.show_steamspy_info === undefined) { settings.show_steamspy_info = true; storage.set({'show_steamspy_info': settings.show_steamspy_info}); }
-		if (settings.show_carousel_descriptions === undefined) { settings.show_carousel_descriptions = true; storage.set({'show_carousel_descriptions': settings.show_carousel_descriptions}); }
-		if (settings.show_early_access === undefined) { settings.show_early_access = true; storage.set({'show_early_access': settings.show_early_access}); }
-		if (settings.show_alternative_linux_icon === undefined) { settings.show_alternative_linux_icon = false; storage.set({'show_alternative_linux_icon': settings.show_alternative_linux_icon}); }
-		if (settings.show_itad_button === undefined) { settings.show_itad_button = false; storage.set({'show_itad_button': settings.show_itad_button}); }
-		if (settings.skip_got_steam === undefined) { settings.skip_got_steam = false; storage.set({'skip_got_steam': settings.skip_got_steam}); }
-		
-		if (settings.hideinstallsteambutton === undefined) { settings.hideinstallsteambutton = false; storage.set({'hideinstallsteambutton': settings.hideinstallsteambutton}); }
-		if (settings.hideaboutmenu === undefined) { settings.hideaboutmenu = false; storage.set({'hideaboutmenu': settings.hideaboutmenu}); }
-		if (settings.replaceaccountname === undefined) { settings.replaceaccountname = false; storage.set({'replaceaccountname': settings.replaceaccountname}); }
-		if (settings.showfakeccwarning === undefined) { settings.showfakeccwarning = true; storage.set({'showfakeccwarning': settings.showfakeccwarning}); }
-		if (settings.showlanguagewarning === undefined) { settings.showlanguagewarning = true; storage.set({'showlanguagewarning': settings.showlanguagewarning}); }
-		if (settings.showlanguagewarninglanguage === undefined) { settings.showlanguagewarninglanguage = "English"; storage.set({'showlanguagewarninglanguage': settings.showlanguagewarninglanguage}); }
-		if (settings.homepage_tab_selection === undefined) { settings.homepage_tab_selection = "remember"; storage.set({'homepage_tab_selection': settings.homepage_tab_selection}); }
-		if (settings.send_age_info === undefined) { settings.send_age_info = true; storage.set({'send_age_info': settings.send_age_info}); }
-		if (settings.html5video === undefined) { settings.html5video = true; storage.set({'html5video': settings.html5video}); }
-		if (settings.contscroll === undefined) { settings.contscroll = true; storage.set({'contscroll': settings.contscroll}); }
-		if (settings.showdrm === undefined) { settings.showdrm = true; storage.set({'showdrm': settings.showdrm}); }
-		if (settings.show_acrtag_info === undefined) { settings.show_acrtag_info = false; storage.set({'show_acrtag_info': settings.show_acrtag_info}); }
-		if (settings.regional_hideworld===undefined) { settings.regional_hideworld = false; storage.set({'regional_hideworld': settings.regional_hideworld});}
-		if (settings.showinvnav === undefined) { settings.showinvnav = false; storage.set({'showinvnav': settings.showinvnav}); }
-		if (settings.showesbg === undefined) { settings.showesbg = true; storage.set({'showesbg': settings.showesbg}); }
-		if (settings.quickinv === undefined) { settings.quickinv = true; storage.set({'quickinv': settings.quickinv}); }
-		if (settings.quickinv_diff === undefined) { settings.quickinv_diff = -0.01; storage.set({'quickinv_diff': settings.quickinv_diff}); }
-		if (settings.showallachievements === undefined) { settings.showallachievements = false; storage.set({'showallachievements': settings.showallachievements}); }
-		if (settings.showcomparelinks === undefined) { settings.showcomparelinks = false; storage.set({'showcomparelinks': settings.showcomparelinks}); }
-		if (settings.showgreenlightbanner === undefined) { settings.showgreenlightbanner = false; storage.set({'showgreenlightbanner': settings.showgreenlightbanner}); }
-		if (settings.dynamicgreenlight === undefined) { settings.dynamicgreenlight = false; storage.set({'dynamicgreenlight': settings.dynamicgreenlight}); }
-		if (settings.remembergreenlightfilter === undefined) { settings.remembergreenlightfilter = false; storage.set({'remembergreenlightfilter': settings.remembergreenlightfilter}); }
-		if (settings.endlessscrollinggreenlight === undefined) { settings.endlessscrollinggreenlight = true; storage.set({'endlessscrollinggreenlight': settings.endlessscrollinggreenlight}); }
-		if (settings.hideactivelistings === undefined) { settings.hideactivelistings = false; storage.set({'hideactivelistings': settings.hideactivelistings}); }
-		if (settings.hidespamcomments === undefined) { settings.hidespamcomments = false; storage.set({'hidespamcomments': settings.hidespamcomments}); }
-		if (settings.spamcommentregex === undefined) { settings.spamcommentregex = "[\\u2500-\\u25FF]"; storage.set({'spamcommentregex': settings.spamcommentregex}); }
-		if (settings.wlbuttoncommunityapp === undefined) { settings.wlbuttoncommunityapp = true; storage.set({'wlbuttoncommunityapp': settings.wlbuttoncommunityapp}); }
-		if (settings.removeguideslanguagefilter === undefined) { settings.removeguideslanguagefilter = false; storage.set({'removeguideslanguagefilter': settings.removeguideslanguagefilter}); }
-		if (settings.disablelinkfilter === undefined) { settings.disablelinkfilter = false; storage.set({'disablelinkfilter': settings.disablelinkfilter}); }
-		if (settings.show1clickgoo === undefined) { settings.show1clickgoo = true; storage.set({'show1clickgoo': settings.show1clickgoo}); }
-		if (settings.show_profile_link_images === undefined) { settings.show_profile_link_images = "gray"; storage.set({'show_profile_link_images': settings.show_profile_link_images}); }
-		if (settings.profile_steamgifts === undefined) { settings.profile_steamgifts = true; storage.set({'profile_steamgifts': settings.profile_steamgifts}); }
-		if (settings.profile_steamrep === undefined) { settings.profile_steamrep = true; storage.set({'profile_steamrep': settings.profile_steamrep}); }
-		if (settings.profile_steamdbcalc === undefined) { settings.profile_steamdbcalc = true; storage.set({'profile_steamdbcalc': settings.profile_steamdbcalc}); }
-		if (settings.profile_astats === undefined) { settings.profile_astats = true; storage.set({'profile_astats': settings.profile_astats}); }
-		if (settings.profile_backpacktf === undefined) { settings.profile_backpacktf = true; storage.set({'profile_backpacktf': settings.profile_backpacktf}); }
-		if (settings.profile_astatsnl === undefined) { settings.profile_astatsnl = true; storage.set({'profile_astatsnl': settings.profile_astatsnl}); }
-		if (settings.profile_api_info === undefined) { settings.profile_api_info = false; storage.set({'profile_api_info': settings.profile_api_info}); }
-		if (settings.api_key == false||settings.api_key==""||settings.api_key===undefined){ settings.profile_api_info = false; storage.set({'profile_api_info': settings.profile_api_info});}
-		if (settings.profile_permalink === undefined) { settings.profile_permalink = true; storage.set({'profile_permalink': settings.profile_permalink}); }
-		if (settings.steamcardexchange == undefined) { settings.steamcardexchange = true; storage.set({'steamcardexchange': settings.steamcardexchange}); }
-		
-		// Load Store Options
-		$("#highlight_owned_color").val(settings.highlight_owned_color);
-		$("#highlight_wishlist_color").val(settings.highlight_wishlist_color);
-		$("#highlight_coupon_color").val(settings.highlight_coupon_color);
-		$("#highlight_inv_gift_color").val(settings.highlight_inv_gift_color);
-		$("#highlight_inv_guestpass_color").val(settings.highlight_inv_guestpass_color);
-		$("#highlight_notinterested_color").val(settings.highlight_notinterested_color);
-
-		$("#tag_owned_color").val(settings.tag_owned_color);
-		$("#tag_owned_color").val(settings.tag_owned_color);
-		$("#tag_wishlist_color").val(settings.tag_wishlist_color);
-		$("#tag_coupon_color").val(settings.tag_coupon_color);
-		$("#tag_inv_gift_color").val(settings.tag_inv_gift_color);
-		$("#tag_inv_guestpass_color").val(settings.tag_inv_guestpass_color);
-		$("#tag_notinterested_color").val(settings.tag_notinterested_color);
-
-		$("#highlight_owned").prop('checked', settings.highlight_owned);
-		$("#highlight_wishlist").prop('checked', settings.highlight_wishlist);
-		$("#highlight_coupon").prop('checked', settings.highlight_coupon);
-		$("#highlight_inv_gift").prop('checked', settings.highlight_inv_gift);
-		$("#highlight_inv_guestpass").prop('checked', settings.highlight_inv_guestpass);
-		$("#highlight_notinterested").prop('checked', settings.highlight_notinterested);
-		$("#highlight_excludef2p").prop('checked', settings.highlight_excludef2p);
-
-		$("#tag_owned").prop('checked', settings.tag_owned);
-		$("#tag_wishlist").prop('checked', settings.tag_wishlist);
-		$("#tag_coupon").prop('checked', settings.tag_coupon);
-		$("#tag_inv_gift").prop('checked', settings.tag_inv_gift);
-		$("#tag_inv_guestpass").prop('checked', settings.tag_inv_guestpass);
-		$("#tag_notinterested").prop('checked', settings.tag_notinterested);
-		$("#tag_short").prop('checked', settings.tag_short);
-		
-		$("#hide_owned").prop('checked', settings.hide_owned);
-		$("#hidetmsymbols").prop('checked', settings.hidetmsymbols);
-
-		$("#hideinstallsteambutton").prop('checked', settings.hideinstallsteambutton);
-		$("#hideaboutmenu").prop('checked', settings.hideaboutmenu);
-		$("#replaceaccountname").prop('checked', settings.replaceaccountname);
-		$("#showfakeccwarning").prop('checked', settings.showfakeccwarning);
-		$("#showlanguagewarning").prop('checked', settings.showlanguagewarning);
-		$("#warning_language").val(settings.showlanguagewarninglanguage);
-		$("#homepage_tab_selection").val(settings.homepage_tab_selection);
-		$("#send_age_info").prop('checked', settings.send_age_info);
-		$("#html5video").prop('checked', settings.html5video);
-		$("#contscroll").prop('checked', settings.contscroll);
-		$("#showdrm").prop('checked', settings.showdrm);
-		$("#showacrtag").prop('checked', settings.show_acrtag_info);
-		$("#showmcus").prop('checked', settings.showmcus);
-		$("#showhltb").prop('checked', settings.showhltb);
-		$("#showpcgw").prop('checked', settings.showpcgw);
-		$("#showclient").prop('checked', settings.showclient);
-		$("#showsteamcardexchange").prop('checked', settings.showsteamcardexchange);
-		$("#showsteamdb").prop('checked', settings.showsteamdb);
-		$("#showastatslink").prop('checked', settings.showastatslink);
-		$("#showwsgf").prop('checked', settings.showwsgf);
-		$("#show_package_info").prop('checked', settings.show_package_info);
-		$("#show_sysreqcheck").prop('checked', settings.show_sysreqcheck);
-		$("#show_steamchart_info").prop('checked', settings.show_steamchart_info);
-		$("#show_steamspy_info").prop('checked', settings.show_steamspy_info);
-		$("#show_carousel_descriptions").prop('checked', settings.show_carousel_descriptions);
-		$("#show_early_access").prop('checked', settings.show_early_access);
-		$("#show_alternative_linux_icon").prop('checked', settings.show_alternative_linux_icon);
-		$("#show_itad_button").prop('checked', settings.show_itad_button);
-		$("#skip_got_steam").prop('checked', settings.skip_got_steam);
-				
-		// Load Price Options
-		$("#showlowestprice").prop('checked', settings.showlowestprice);
-		$("#showlowestprice_onwishlist").prop('checked', settings.showlowestprice_onwishlist);
-		$("#showlowestpricecoupon").prop('checked', settings.showlowestpricecoupon);
-		$("#stores_all").prop('checked', settings.showallstores);
-		toggle_stores();
-		$("#override_price").val(settings.override_price);
-		$("#regional_price_on").val(settings.showregionalprice);
-		$("#regional_hideworld").prop('checked', settings.regional_hideworld);
+		if (!settings.profile_api_info){ $("#api_key_block").hide(); }
 		if (settings.showregionalprice == "off") { $("#region_selects").hide(); }
 		if (settings.showregionalprice != "mouse") { $("#regional_price_hideworld").hide(); }
+
+		toggle_stores();
 		populate_regional_selects();
-
-		// Load Community Options
-		$("#showtotal").prop('checked', settings.showtotal);
-		$("#showmarkettotal").prop('checked', settings.showmarkettotal);
-		$("#showsteamrepapi").prop('checked', settings.showsteamrepapi);
-		$("#showinvnav").prop('checked', settings.showinvnav);
-		$("#showesbg").prop('checked', settings.showesbg);
-		$("#quickinv").prop('checked', settings.quickinv);
-		$("#quickinv_diff").val(settings.quickinv_diff);
-		$("#showallachievements").prop('checked', settings.showallachievements);
-		$("#showcomparelinks").prop('checked', settings.showcomparelinks);
-		$("#showgreenlightbanner").prop('checked', settings.showgreenlightbanner);
-		$("#dynamicgreenlight").prop('checked', settings.dynamicgreenlight);
-		$("#remembergreenlightfilter").prop('checked', settings.remembergreenlightfilter);
-		$("#endlessscrollinggreenlight").prop('checked', settings.endlessscrollinggreenlight);
-		$("#hideactivelistings").prop('checked', settings.hideactivelistings);
-		$("#hidespamcomments").prop('checked', settings.hidespamcomments);
-		$("#spamcommentregex").val(settings.spamcommentregex);
-		$("#wlbuttoncommunityapp").prop('checked', settings.wlbuttoncommunityapp);
-		$("#removeguideslanguagefilter").prop('checked', settings.removeguideslanguagefilter);
-		$("#disablelinkfilter").prop('checked', settings.disablelinkfilter);
-		$("#show1clickgoo").prop('checked', settings.show1clickgoo);
-		$("#profile_link_images_dropdown").val(settings.show_profile_link_images);
-
-		// Load Profile Link Options
-		$("#profile_steamgifts").prop('checked', settings.profile_steamgifts);
-		$("#profile_steamrep").prop('checked', settings.profile_steamrep);
-		$("#profile_steamdbcalc").prop('checked', settings.profile_steamdbcalc);
-		$("#profile_wastedonsteam").prop('checked', settings.profile_wastedonsteam);
-		$("#profile_astats").prop('checked', settings.profile_astats);
-		$("#profile_backpacktf").prop('checked', settings.profile_backpacktf);
-		$("#profile_astatsnl").prop('checked', settings.profile_astatsnl);
-		$("#profile_api_info").prop('checked', settings.profile_api_info);
-		if(!settings.profile_api_info){$("#api_key_block").hide()}
-		$("#api_key").val(settings.api_key)
-		$("#profile_permalink").prop('checked', settings.profile_permalink);
-		$("#steamcardexchange").prop('checked', settings.steamcardexchange);
 		
-		if(!changelog_loaded) {		
-			jQuery.get('changelog.txt', function(data) {
+		if (!changelog_loaded) {		
+			$.get('changelog.txt', function(data) {
 				$("#changelog_text").after("<textarea rows=28 cols=100 readonly>" + data + "</textarea>");
 			});
-			changelog_loaded=true;
+			changelog_loaded = true;
 		}
 
 		load_translation();
@@ -660,6 +285,7 @@ function load_translation() {
 				case "ukrainian": l_code = "uk"; break;
 				default: l_code = "en"; break;
 			}
+
 			$.getJSON(chrome.extension.getURL('/localization/en/strings.json'), function (data) {
 				if (l_code == "en") {
 					localized_strings = data;
@@ -671,86 +297,37 @@ function load_translation() {
 					});
 				}
 			});
+
 			return l_deferred.promise();
 		})();
 
+		// When locale files are loaded changed text on page accordingly
 		localization_promise.done(function(){
 			document.title = "Enhanced Steam " + localized_strings.thewordoptions;
-			
-			$("#nav_store").text(localized_strings.store);
-			$("#nav_price").text(localized_strings.price);
-			$("#nav_community").text(localized_strings.community);
-			$("#nav_news").text(localized_strings.news);
-			$("#nav_about").text(localized_strings.about);
-			$("#nav_credits").text(localized_strings.credits);
-			$("#nav_donate").text(localized_strings.donate);
-			
-			$("#language_text").text(localized_strings.language);
-			
-			$("#highlight_text").text(localized_strings.highlight);
-			$("#highlight_owned_text").text(localized_strings.options.owned);
-			$("#highlight_wishlist_text").text(localized_strings.options.wishlist);
-			$("#highlight_coupon_text").text(localized_strings.options.coupon);
-			$("#highlight_gift_text").text(localized_strings.options.gift);
-			$("#highlight_guest_text").text(localized_strings.options.guest);
-			$("#highlight_notinterested_text").text(localized_strings.notinterested);
-			$("#highlight_excludef2p_text").text(localized_strings.options.excludef2p);
 
-			$("#tag_text").text(localized_strings.options.tag);
-			$("#tag_owned_text").text(localized_strings.options.owned);
-			$("#tag_wishlist_text").text(localized_strings.options.wishlist);
-			$("#tag_coupon_text").text(localized_strings.options.coupon);
-			$("#tag_gift_text").text(localized_strings.options.gift);
-			$("#tag_guest_text").text(localized_strings.options.guest);
-			$("#tag_notinterested_text").text(localized_strings.notinterested);
-			$("#tag_short_text").text(localized_strings.tags_short);
-			
-			$("#hide_text").text(localized_strings.hide);
-			$("#hide_owned_text").text(localized_strings.options.hide_owned);
-			$("#hidetmsymbols_text").text(localized_strings.options.hidetmsymbols);
+			// Source: http://stackoverflow.com/a/24221895
+			function resolveObjPath(obj, path) {
+				path = path.split('.').reverse();
+				var current = obj;
 
-			$("#store_hide_install_text").text(localized_strings.options.hide_install);
-			$("#store_hide_about_menu").text(localized_strings.options.hide_about);
-			$("#store_replace_account_name").text(localized_strings.options.replace_account_name);
-			$("#store_general").text(localized_strings.options.general);
-			$("#header_showfakeccwarning_text").text(localized_strings.options.show_regionwarning);
-			$("#store_show_languagewarning_text").text(localized_strings.options.show_languagewarning);
-			$("#homepage_text").text(localized_strings.options.homepage);
-			$("#homepage_default_tab_text").text(localized_strings.options.homepage_default_tab + ":");
-			$("select#homepage_tab_selection option[value=remember]").text(localized_strings.options.homepage_default_tab_remember);
-			$("select#homepage_tab_selection option[value=tab_newreleases_content_trigger]").text(localized_strings.options.homepage_default_tab_newreleases);
-			$("select#homepage_tab_selection option[value=es_allreleases]").text(localized_strings.options.homepage_default_tab_allreleases);
-			$("select#homepage_tab_selection option[value=tab_topsellers_content_trigger]").text(localized_strings.options.homepage_default_tab_topsellers);
-			$("select#homepage_tab_selection option[value=tab_upcoming_content_trigger]").text(localized_strings.options.homepage_default_tab_upcoming);
-			$("select#homepage_tab_selection option[value=tab_specials_content_trigger]").text(localized_strings.options.homepage_default_tab_specials);
-			$("select#homepage_tab_selection option[value=es_popular]").text(localized_strings.popular);
-			$("#send_age_info_text").text(localized_strings.options.send_age_info);
-			$("#html5video_text").text(localized_strings.options.html5video);
-			$("#contscroll_text").text(localized_strings.options.contscroll);
-			$("#store_drm_text").text(localized_strings.options.drm);
-			$("#store_acrtag_text").text(localized_strings.options.acrtag);
-			$("#store_lowestprice_text").text(localized_strings.options.lowestprice);
-			$("#store_lowestprice_onwishlist_text").text(localized_strings.options.lowestprice_onwishlist);
-			$("#store_lowestprice_coupon_text").text(localized_strings.options.lowestprice_coupon);
-			$("#store_lowestprice_header").text(localized_strings.options.lowestprice_header);
-			$("#store_metacritic_text").text(localized_strings.options.metacritic);
-			$("#store_hltb_text").text(localized_strings.options.hltb);
-			$("#store_pcgw_text").text(localized_strings.options.pcgw);
-			$("#store_client_text").text(localized_strings.options.showclient);
-			$("#store_steamcards_text").text(localized_strings.options.store_steamcards);
-			$("#store_steamdb_text").text(localized_strings.options.steamdb);
-			$("#store_astatslink_text").text(localized_strings.options.show_astatslink);
-			$("#store_wsgf_text").text(localized_strings.options.wsgf);
-			$("#store_package_info_text").text(localized_strings.options.show_package_info);
-			$("#show_sysreqcheck_text").text(localized_strings.options.show_sysreqcheck);
-			$("#store_steamchart_info_text").text(localized_strings.options.show_steamchart_info);
-			$("#store_steamspy_info_text").text(localized_strings.options.show_steamspy_info);
-			$("#store_carousel_descriptions_text").text(localized_strings.options.carousel_description);
-			$("#show_early_access_text").text(localized_strings.options.show_early_access_text);
-			$("#show_alternative_linux_icon_text").text(localized_strings.options.show_alternative_linux_icon);
-			$("#show_itad_button_text").text(localized_strings.itad.option);
-			$("#skip_got_steam_text").text(localized_strings.options.skip_got_steam);
-			
+				while (path.length) {
+					if (typeof current !== 'object') return undefined;
+					current = current[path.pop()];
+				}
+
+				return current;
+			}
+
+			// Localize elements with text
+			$("[data-locale-text]").text(function(){
+				return resolveObjPath( localized_strings, $(this).data("locale-text") );
+			});
+
+			// Localize elements with html
+			$("[data-locale-html]").html(function(){
+				return resolveObjPath( localized_strings, $(this).data("locale-html") );
+			});
+
 			$("#warning_language option").each(function() {
 				var lang = $(this).text();
 				var lang_trl = localized_strings.options.lang[this.value.toLowerCase()];
@@ -758,91 +335,21 @@ function load_translation() {
 					$(this).text(lang + " (" + lang_trl + ")");
 				}
 			});
+
 			$.each(localized_strings.options.lang, function(lang, lang_trl) {
-				$(".language."+lang).text(lang_trl+":");
+				$(".language." + lang).text(lang_trl + ":");
 			});
 			
-			$("#lowestprice_stores_text").text(localized_strings.stores);
-			$("#lowestprice_stores_all_text").text(localized_strings.options.stores_all);
-			$("#viewprice_text").text(localized_strings.options.view_in);
-			$("#store_regionalprice_header").text(localized_strings.options.regional_price);
-			$("#showregionalprice_text").text(localized_strings.options.regional_price_on);
-			$('select#regional_price_on option[value=always]').text(localized_strings.always);
-			$('select#regional_price_on option[value=off]').text(localized_strings.never);
-			$('select#regional_price_on option[value=mouse]').text(localized_strings.options.regional_price_mouse);
-			$("#add_another_region").text(localized_strings.options.add_another_region);
-			
-			$("#community_general").text(localized_strings.options.general);
-			$("#community_market").text(localized_strings.options.market);
-			$("#community_inventory").text(localized_strings.options.inventory);
-			$("#community_profile").text(localized_strings.options.profile);
-			$("#community_greenlight").text(localized_strings.options.greenlight);
-			$("#profile_link_text").text(localized_strings.options.profile_links + ":");
-			$("#show_profile_link_images_text").text(localized_strings.options.profile_link_images + ":");
-			$("#profile_link_images_gray").text(localized_strings.options.profile_link_images_gray);
-			$("#profile_link_images_color").text(localized_strings.options.profile_link_images_color);
-			$("#profile_link_images_none").text(localized_strings.options.profile_link_images_none);
-			$("#profile_permalink_text").text(localized_strings.options.profile_permalink);
-			$("#total_spent_text").text(localized_strings.options.total_spent);
-			$("#steamrep_api_text").text(localized_strings.options.steamrepapi);
-			$("#market_total_text").text(localized_strings.options.market_total);
-			$("#hideactivelistings_text").text(localized_strings.options.hideactivelistings);
-			$("#inventory_nav_text").text(localized_strings.options.inventory_nav_text);
-			$("#es_background_text").text(localized_strings.options.es_bg);
-			$("#quickinv_text").text(localized_strings.options.quickinv);
-			$("#quickinv_diff_text").text(localized_strings.options.quickinv_diff);
-			$("#show_quickinv_diff").text("("+localized_strings.customize+")");
-			$("#quickinv_default").text(localized_strings.theworddefault);
-			$("#allachievements_text").text(localized_strings.options.showallachievements);
-			$("#showcomparelinks_text").text(localized_strings.options.showcomparelinks);
-			$("#greenlight_banner_text").text(localized_strings.options.greenlight_banner);
-			$("#dynamicgreenlight_text").text(localized_strings.options.dynamicgreenlight);
-			$("#remembergreenlightfilter_text").text(localized_strings.options.remembergreenlightfilter);
-			$("#endlessscrollinggreenlight_text").text(localized_strings.options.endlessscrollinggreenlight);
-			$("#hidespamcomments_text").text(localized_strings.options.hidespamcomments);
-			$("#spamcommentregex_text").text(localized_strings.options.spamcommentregex);
-			$("#show_spamcommentregex").text("("+localized_strings.customize+")");
-			$("#spamcommentregex_default").text(localized_strings.theworddefault);
-			$("#steamcardexchange_text").text(localized_strings.options.steamcardexchange);
-			$("#wlbuttoncommunityapp_text").text(localized_strings.options.wlbuttoncommunityapp);
-			$("#removeguideslanguagefilter_text").text(localized_strings.options.removeguideslanguagefilter);
-			$("#disablelinkfilter_text").text(localized_strings.options.disablelinkfilter);
-			$("#show1clickgoo_text").text(localized_strings.options.show1clickgoo);
+			// These I couldn't find in the html... not sure if I should remove them
+			/*$("#lowestprice_stores_text").text(localized_strings.stores);
 
-			$("#highlight_owned_default").text(localized_strings.theworddefault);
-			$("#highlight_wishlist_default").text(localized_strings.theworddefault);
-			$("#highlight_coupon_default").text(localized_strings.theworddefault);
-			$("#highlight_inv_gift_default").text(localized_strings.theworddefault);
-			$("#highlight_inv_guestpass_default").text(localized_strings.theworddefault);
-			$("#highlight_notinterested_default").text(localized_strings.theworddefault);
 			$("#highlight_friends_want_color_default").text(localized_strings.theworddefault);
-			$("#tag_owned_color_default").text(localized_strings.theworddefault);
-			$("#tag_wishlist_default").text(localized_strings.theworddefault);
-			$("#tag_coupon_default").text(localized_strings.theworddefault);
-			$("#tag_inv_gift_default").text(localized_strings.theworddefault);
-			$("#tag_inv_guestpass_default").text(localized_strings.theworddefault);
-			$("#tag_notinterested_default").text(localized_strings.theworddefault);
 			$("#tag_friends_want_color_default").text(localized_strings.theworddefault);
 			$("#tag_friends_own_color_default").text(localized_strings.theworddefault);
 			$("#tag_friends_rec_color_default").text(localized_strings.theworddefault);
 			$("#reset_countries").text(localized_strings.theworddefault);
 
-			$("#regional_hideworld_text").text(localized_strings.options.regional_hideworld);
-			
-			$("#es_about_text").html(localized_strings.options.about_text);
-			$("#changelog_text").text(localized_strings.options.changelog);
-			
-			$("#programming_text").text(localized_strings.programming);
-			$("#view_all").html("<a href='https://github.com/jshackles/Enhanced_Steam/graphs/contributors'>" + localized_strings.view_all + "</a>");
-			$("#translation_text").text(localized_strings.translation);
-			$("#graphics_text").text(localized_strings.graphics);
-
-			$("#reset").text(localized_strings.options.reset);
-			$("#saved").text(localized_strings.options.saved_note);
-			$("#reset_note").text(localized_strings.options.reset_note);
-
-			$("#foot_link").text(localized_strings.options.foot_link);
-			$("#author_info").text(localized_strings.options.author_info);
+			$("#graphics_text").text(localized_strings.graphics);*/
 		});	
 	});
 }
@@ -904,11 +411,6 @@ function generate_region_select() {
 	return region_selection;
 }
 
-function remove_region() {
-	$(this).closest('li').remove();
-	save_options();
-}
-
 function get_http(url, callback) {
 	var http = new XMLHttpRequest();
 	http.onreadystatechange = function () {
@@ -933,7 +435,7 @@ function steam_credits() {
 function clear_settings() {
 	storage.get(function(settings) {
 		var confirm_reset = confirm(localized_strings.options.clear);
-		if(confirm_reset){
+		if (confirm_reset) {
 			storage.clear();
 			load_options();
 			$("#reset_note").stop(true,true).fadeIn().delay(600).fadeOut();
@@ -946,20 +448,6 @@ function change_flag(node, selectnode) {
 	node.addClass("es_flag_" + selectnode.val() +" es_flag");
 }
 
-function load_default_highlight_owned_color() { $("#highlight_owned_color").val( highlight_defaults.owned ); }
-function load_default_highlight_wishlist_color() { $("#highlight_wishlist_color").val( highlight_defaults.wishlist ); }
-function load_default_highlight_coupon_color() { $("#highlight_coupon_color").val( highlight_defaults.coupon ); }
-function load_default_highlight_inv_gift_color() { $("#highlight_inv_gift_color").val ( highlight_defaults.inv_gift ); }
-function load_default_highlight_inv_guestpass_color() { $("#highlight_inv_guestpass_color").val( highlight_defaults.inv_guestpass ); }
-function load_default_highlight_notinterested_color() { $("#highlight_notinterested_color").val( highlight_defaults.notinterested ); }
-
-function load_default_tag_owned_color() { $("#tag_owned_color").val( highlight_defaults.owned ); }
-function load_default_tag_wishlist_color() { $("#tag_wishlist_color").val( highlight_defaults.wishlist ); }
-function load_default_tag_coupon_color() { $("#tag_coupon_color").val( highlight_defaults.coupon ); }
-function load_default_tag_inv_gift_color() { $("#tag_inv_gift_color").val( highlight_defaults.inv_gift ); }
-function load_default_tag_inv_guestpass_color() { $("#tag_inv_guestpass_color").val( highlight_defaults.inv_guestpass ); }
-function load_default_tag_notinterested_color() { $("#tag_notinterested_color").val( highlight_defaults.notinterested ); }
-
 function load_default_countries() {
 	regional_countries = ["us","gb","eu1","ru","br","au","jp"];
 	storage.set({'regional_countries': regional_countries}, function() {
@@ -969,71 +457,73 @@ function load_default_countries() {
 	});	
 }
 
-function toggle_regex() {$("#spamcommentregex_list").toggle()}
-function load_default_spamcommentregex(){$("#spamcommentregex").val("[\\u2500-\\u25FF]")}
-
 $(document).ready(function(){
 	load_options();
-	$("#language").change(load_translation);
 	load_profile_link_images();
-	$("#profile_link_images_dropdown").change(load_profile_link_images);
-	$("#highlight_owned_default").click(load_default_highlight_owned_color);
-	$("#highlight_wishlist_default").click(load_default_highlight_wishlist_color);
-	$("#highlight_coupon_default").click(load_default_highlight_coupon_color);
-	$("#highlight_inv_gift_default").click(load_default_highlight_inv_gift_color);
-	$("#highlight_inv_guestpass_default").click(load_default_highlight_inv_guestpass_color);
-	$("#highlight_notinterested_default").click(load_default_highlight_notinterested_color);
 
-	$("#tag_owned_color_default").click(load_default_tag_owned_color);
-	$("#tag_wishlist_default").click(load_default_tag_wishlist_color);
-	$("#tag_coupon_default").click(load_default_tag_coupon_color);
-	$("#tag_inv_gift_default").click(load_default_tag_inv_gift_color);
-	$("#tag_inv_guestpass_default").click(load_default_tag_inv_guestpass_color);
-	$("#tag_notinterested_default").click(load_default_tag_notinterested_color);
+	$("#language").on("change", load_translation);
+	$("#profile_link_images_dropdown").on("change", load_profile_link_images);
 
-	$("#spamcommentregex_default").click(load_default_spamcommentregex);
-	$("#quickinv_default").click(function() { $("#quickinv_diff").val("-0.01"); });
+	$("#highlight_owned_default").on("click", function(){ $("#highlight_owned_color").val( highlight_defaults.owned ); });
+	$("#highlight_wishlist_default").on("click", function(){ $("#highlight_wishlist_color").val( highlight_defaults.wishlist ); });
+	$("#highlight_coupon_default").on("click", function(){ $("#highlight_coupon_color").val( highlight_defaults.coupon ); });
+	$("#highlight_inv_gift_default").on("click", function(){ $("#highlight_inv_gift_color").val( highlight_defaults.inv_gift ); });
+	$("#highlight_inv_guestpass_default").on("click", function(){ $("#highlight_inv_guestpass_color").val( highlight_defaults.inv_guestpass ); });
+	$("#highlight_notinterested_default").on("click", function(){ $("#highlight_notinterested_color").val( highlight_defaults.notinterested ); });
+
+	$("#tag_owned_color_default").on("click", function(){ $("#tag_owned_color").val( highlight_defaults.owned ); });
+	$("#tag_wishlist_default").on("click", function(){ $("#tag_wishlist_color").val( highlight_defaults.wishlist ); });
+	$("#tag_coupon_default").on("click", function(){ $("#tag_coupon_color").val( highlight_defaults.coupon ); });
+	$("#tag_inv_gift_default").on("click", function(){ $("#tag_inv_gift_color").val( highlight_defaults.inv_gift ); });
+	$("#tag_inv_guestpass_default").on("click", function(){ $("#tag_inv_guestpass_color").val( highlight_defaults.inv_guestpass ); });
+	$("#tag_notinterested_default").on("click", function(){ $("#tag_notinterested_color").val( highlight_defaults.notinterested ); });
+
+	$("#spamcommentregex_default").on("click", function(){ $("#spamcommentregex").val("[\\u2500-\\u25FF]"); });
+	$("#quickinv_default").on("click", function() { $("#quickinv_diff").val("-0.01"); });
 	$("#quickinv_diff").focusout(function() { if (isNaN(parseFloat($("#quickinv_diff").val()))) { $("#quickinv_diff").val("-0.01"); } });
 
-	$('#nav_store').click(load_store_tab);
-	$('#nav_price').click(load_price_tab);
-	$('#nav_community').click(load_community_tab);
-	$('#nav_news').click(load_news_tab);
-	$('#nav_about').click(load_about_tab);
-	$('#nav_credits').click(load_credits_tab);
-
-	$("#show_spamcommentregex").click(toggle_regex);
-	$("#show_quickinv_diff").click(function() { $("#quickinv_opt").toggle() });
-	$('#stores_all').click(toggle_stores);
-	$("#reset_countries").click(load_default_countries);
+	$("#show_spamcommentregex").on("click", function(){ $("#spamcommentregex_list").toggle(); });
+	$("#show_quickinv_diff").on("click", function() { $("#quickinv_opt").toggle(); });
+	$('#stores_all').on("change", toggle_stores);
+	$("#reset_countries").on("click", load_default_countries);
 	$('#region_selects').on('change', '.regional_country', function() {
 		var $this = $(this);
 		change_flag($this.siblings('.es_flag'), $this);
 		save_options();
-	}).on('click', '.remove_region', remove_region);
-
-	$('#add_another_region').click(add_region_selector);
-
-	$("#regional_price_on").change(function() {
-		if ($(this).val() == "off") { $("#region_selects").hide(); } else { $("#region_selects").show(); }
-		if ($(this).val() == "mouse") {
-			$("#regional_price_hideworld").show();
-		} else {
-			$("#regional_price_hideworld").hide();
-		}
+	}).on('click', '.remove_region', function(){
+		$(this).closest('li').remove();
+		save_options();
 	});
 
-	$("#profile_api_info").change(function(){
-		if($(this).prop("checked")) {$("#api_key_block").show()}
-		else{$("#api_key_block").hide()}
-	})
+	$('#add_another_region').on("click", add_region_selector);
 
-	$("input[type=checkbox]").click(save_options);
-	$("input[type=text]").blur(save_options);
-	$("button:not(#reset):not(#reset_countries):not(#add_another_region)").click(save_options);
-	$("#reset").click(clear_settings);
-	$(".colorbutton").change(save_options);
-	$("select").change(save_options);
+	$("#regional_price_on").on("change", function() {
+		$("#region_selects").toggle($(this).val() != "off");
+		$("#regional_price_hideworld").toggle($(this).val() == "mouse");
+	});
+
+	$("#profile_api_info").on("change", function(){
+		$("#api_key_block").toggle($(this).prop("checked"));
+	});
+
+	// Toggle tabs content
+	$("a.tab_row").on("click", function(){
+		var block_sel = $(this).data("block-sel");
+
+		$(".content").hide();
+		$(block_sel).show();
+
+		$(".selected").removeClass("selected");
+		$(this).addClass("selected");
+	});
+
+	$("input[type=checkbox]").on("change", save_options);
+	$("input[type=text]").on("blur", save_options);
+	$("button:not(#reset):not(#reset_countries):not(#add_another_region)").on("click", save_options);
+	$(".colorbutton").on("change", save_options);
+	$("select").on("change", save_options);
+
+	$("#reset").on("click", clear_settings);
 
 	steam_credits();
 });

--- a/js/options.js
+++ b/js/options.js
@@ -49,7 +49,37 @@ var settings_defaults = {
 	"showlowestprice_onwishlist": true,
 	"showlowestpricecoupon": true,
 	"showallstores": true,
-	"stores": [true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true],
+	"stores": {
+		"steam": true,
+		"amazonus": true,
+		"impulse": true,
+		"gamersgate": true,
+		"greenmangaming": true,
+		"direct2drive": true,
+		"origin": true,
+		"uplay": true,
+		"indiegalastore": true,
+		"gamesplanet": true,
+		"indiegamestand": true,
+		"gog": true,
+		"dotemu": true,
+		"nuuvem": true,
+		"dlgamer": true,
+		"humblestore": true,
+		"squenix": true,
+		"bundlestars": true,
+		"fireflower": true,
+		"humblewidgets": true,
+		"newegg": true,
+		"gamesrepublic": true,
+		"coinplay": true,
+		"funstock": true,
+		"wingamestore": true,
+		"gamebillet": true,
+		"silagames": true,
+		"playfield": true,
+		"imperialgames": true
+	},
 	"override_price": "auto",
 	"showregionalprice": "mouse",
 	"regional_countries": ["us", "gb", "eu1", "ru", "br", "au", "jp"],
@@ -93,6 +123,7 @@ var settings_defaults = {
 	"quickinv": true,
 	"quickinv_diff": -0.01,
 	"showallachievements": false,
+	"showachinstore": true,
 	"showcomparelinks": false,
 	"showgreenlightbanner": false,
 	"dynamicgreenlight": false,
@@ -136,8 +167,9 @@ function save_options() {
 
 	// Get checked stores, but only if loaded already from storage
 	if (!$("#stores_all").prop('checked') && $("#store_stores").hasClass("es_checks_loaded")) {
-		saveSettings.stores = $.map($("#store_stores").find("input[type='checkbox']"), function(el, i) {
-			return $(el).prop("checked");
+		saveSettings.stores = {};
+		$("#store_stores").find("input[type='checkbox']").each(function(i, el) {
+			saveSettings.stores[$(this).prop("id")] = $(this).prop("checked");
 		});
 	}
 
@@ -169,7 +201,7 @@ function toggle_stores() {
 		$("#store_stores").show();
 		storage.get(function(settings) {
 			$("#store_stores").addClass("es_checks_loaded").find("input[type='checkbox']").each(function(i, checkbox) {
-				$(checkbox).prop("checked", settings.stores[i]);
+				$(checkbox).prop("checked", settings.stores[$(this).prop("id")]);
 			});
 		});
 	}
@@ -214,6 +246,12 @@ function load_options() {
 
 		// Initiate settings against the defaults
 		settings = checkSettings(settings_defaults, settings);
+		
+		// Change the way we store stores settings
+		if (settings.stores instanceof Array) {
+			settings.stores = settings_defaults.stores;
+			storage.set({"stores": settings_defaults.stores});
+		}
 
 		// Set the value or state for each input
 		$("[data-setting]").each(function(){

--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -388,6 +388,7 @@
         "wishlist": "Items on your wishlist",
         "add_another_region": "Add",
         "skip_got_steam": "Skip the 'Got Steam?' window",
+        "store_general_thirdparty": "Options for information from 3rd party sites",
         "lang": {
             "english": "English",
             "brazilian": "Portuguese-Brazil",

--- a/options.html
+++ b/options.html
@@ -13,153 +13,153 @@
 
 	<div id="header">
 		<div id="header_logo"><img src="img/logo.png"></div>
-		<span class="notification" id="saved">Options saved</span>
-		<span class="notification" id="reset_note">Options reset</span>
+		<span class="notification" id="saved" data-locale-text="options.saved_note">Options saved</span>
+		<span class="notification" id="reset_note" data-locale-text="options.reset_note">Options reset</span>
 	</div>
 
 	<div id="side_bar">
-		<a class="tab_row selected" id="nav_store">Store</a>
-		<a class="tab_row" id="nav_price">Price</a>
-		<a class="tab_row" id="nav_community">Community</a>
-		<a class="tab_row" id="nav_news">News</a>
-		<a class="tab_row" id="nav_about">About</a>
-		<a class="tab_row" id="nav_credits">Credits</a>
-		<a class="tab_row" id="nav_donate" href="http://www.EnhancedSteam.com/donate.php">Donate</a>
+		<a class="tab_row selected" id="nav_store" data-locale-text="store" data-block-sel="#maincontent_store">Store</a>
+		<a class="tab_row" id="nav_price" data-locale-text="price" data-block-sel="#maincontent_price">Price</a>
+		<a class="tab_row" id="nav_community" data-locale-text="community" data-block-sel="#maincontent_community">Community</a>
+		<a class="tab_row" id="nav_news" data-locale-text="news" data-block-sel="#maincontent_news">News</a>
+		<a class="tab_row" id="nav_about" data-locale-text="about" data-block-sel="#maincontent_about">About</a>
+		<a class="tab_row" id="nav_credits" data-locale-text="credits" data-block-sel="#maincontent_credits">Credits</a>
+		<a class="tab_row" id="nav_donate" data-locale-text="donate" href="http://www.EnhancedSteam.com/donate.php">Donate</a>
 	</div>
 
 	<div id="contentwrapper">
 		<div id="maincontent_store" class="content">
 			<ul>
-				<li class="header" id="highlight_text">Highlight</li>
+				<li class="header" id="highlight_text" data-locale-text="highlight">Highlight</li>
 				<div>
 					<li class="settings_check">
-						<input type="checkbox" id="highlight_owned"><label for="highlight_owned" id="highlight_owned_text">Items you own</label>
+						<input type="checkbox" id="highlight_owned" data-setting="highlight_owned"><label for="highlight_owned" id="highlight_owned_text" data-locale-text="options.owned">Items you own</label>
 						<a href="http://enhancedsteam.com/featuredetail.php?id=1" class="help"></a>
 					</li>
 					<li class="settings_color">
-						<input type="color" id="highlight_owned_color" class="colorbutton">
-						<button id="highlight_owned_default" class="btn">Default</button>
+						<input type="color" id="highlight_owned_color" data-setting="highlight_owned_color" class="colorbutton">
+						<button id="highlight_owned_default" class="btn" data-locale-text="theworddefault">Default</button>
 					</li>
 				</div>
 				<div>
 					<li class="settings_check">
-						<input type="checkbox" id="highlight_wishlist"><label for="highlight_wishlist" id="highlight_wishlist_text">Items on your wishlist</label>
+						<input type="checkbox" id="highlight_wishlist" data-setting="highlight_wishlist"><label for="highlight_wishlist" id="highlight_wishlist_text" data-locale-text="options.wishlist">Items on your wishlist</label>
 						<a href="http://enhancedsteam.com/featuredetail.php?id=2" class="help"></a>
 					</li>
 					<li class="settings_color">
-						<input type="color" id="highlight_wishlist_color" class="colorbutton">
-						<button id="highlight_wishlist_default" class="btn">Default</button>
+						<input type="color" id="highlight_wishlist_color" data-setting="highlight_wishlist_color" class="colorbutton">
+						<button id="highlight_wishlist_default" class="btn" data-locale-text="theworddefault">Default</button>
 					</li>
 				</div>
 				<div>
 					<li class="settings_check">
-						<input type="checkbox" id="highlight_coupon"><label for="highlight_coupon" id="highlight_coupon_text">Items with coupons</label>
+						<input type="checkbox" id="highlight_coupon" data-setting="highlight_coupon"><label for="highlight_coupon" id="highlight_coupon_text" data-locale-text="options.coupon">Items with coupons</label>
 					</li>
 					<li class="settings_color">
-						<input type="color" id="highlight_coupon_color" class="colorbutton">
-						<button id="highlight_coupon_default" class="btn">Default</button>
+						<input type="color" id="highlight_coupon_color" data-setting="highlight_coupon_color" class="colorbutton">
+						<button id="highlight_coupon_default" class="btn" data-locale-text="theworddefault">Default</button>
 					</li>
 				</div>
 				<div>
 					<li class="settings_check">
-						<input type="checkbox" id="highlight_inv_gift"><label for="highlight_inv_gift" id="highlight_gift_text">Items stored as gift</label>
+						<input type="checkbox" id="highlight_inv_gift" data-setting="highlight_inv_gift"><label for="highlight_inv_gift" id="highlight_gift_text" data-locale-text="options.gift">Items stored as gift</label>
 					</li>
 					<li class="settings_color">
-						<input type="color" id="highlight_inv_gift_color" class="colorbutton">
-						<button id="highlight_inv_gift_default" class="btn">Default</button>
+						<input type="color" id="highlight_inv_gift_color" data-setting="highlight_inv_gift_color" class="colorbutton">
+						<button id="highlight_inv_gift_default" class="btn" data-locale-text="theworddefault">Default</button>
 					</li>
 				</div>
 				<div>
 					<li class="settings_check">
-						<input type="checkbox" id="highlight_inv_guestpass"><label for="highlight_inv_guestpass" id="highlight_guest_text">Items you have a guest pass for</label>
+						<input type="checkbox" id="highlight_inv_guestpass" data-setting="highlight_inv_guestpass"><label for="highlight_inv_guestpass" id="highlight_guest_text" data-locale-text="options.guest">Items you have a guest pass for</label>
 					</li>
 					<li class="settings_color">
-						<input type="color" id="highlight_inv_guestpass_color" class="colorbutton">
-						<button id="highlight_inv_guestpass_default" class="btn">Default</button>
+						<input type="color" id="highlight_inv_guestpass_color" data-setting="highlight_inv_guestpass_color" class="colorbutton">
+						<button id="highlight_inv_guestpass_default" class="btn" data-locale-text="theworddefault">Default</button>
 					</li>
 				</div>
 				<div>
 					<li class="settings_check">
-						<input type="checkbox" id="highlight_notinterested"><label for="highlight_notinterested" id="highlight_notinterested_text">Items marked not interested</label>
+						<input type="checkbox" id="highlight_notinterested" data-setting="highlight_notinterested"><label for="highlight_notinterested" id="highlight_notinterested_text" data-locale-text="options.notinterested">Items marked not interested</label>
 					</li>
 					<li class="settings_color">
-						<input type="color" id="highlight_notinterested_color" class="colorbutton">
-						<button id="highlight_notinterested_default" class="btn">Default</button>
+						<input type="color" id="highlight_notinterested_color" data-setting="highlight_notinterested_color" class="colorbutton">
+						<button id="highlight_notinterested_default" class="btn" data-locale-text="theworddefault">Default</button>
 					</li>
 				</div>
 				<div>
 					<li class="settings_check">
-						<input type="checkbox" id="highlight_excludef2p"><label for="highlight_excludef2p" id="highlight_excludef2p_text">Exclude free to play games from highlighting</label>
+						<input type="checkbox" id="highlight_excludef2p" data-setting="highlight_excludef2p"><label for="highlight_excludef2p" id="highlight_excludef2p_text" data-locale-text="options.excludef2p">Exclude free to play games from highlighting</label>
 					</li>
 				</div>
-				<li class="header" id="tag_text">Tag</li>
+				<li class="header" id="tag_text" data-locale-text="options.tag">Tag</li>
 				<div>
 					<li class="settings_check">
-						<input type="checkbox" id="tag_owned"><label for="tag_owned" id="tag_owned_text">Items you own</label>
+						<input type="checkbox" id="tag_owned" data-setting="tag_owned"><label for="tag_owned" id="tag_owned_text" data-locale-text="options.owned">Items you own</label>
 					</li>
 					<li class="settings_color">
-						<input type="color" id="tag_owned_color" class="colorbutton">
-						<button id="tag_owned_color_default" class="btn">Default</button>
+						<input type="color" id="tag_owned_color" data-setting="tag_owned_color" class="colorbutton">
+						<button id="tag_owned_color_default" class="btn" data-locale-text="theworddefault">Default</button>
 					</li>
 				</div>
 				<div>
 					<li class="settings_check">
-						<input type="checkbox" id="tag_wishlist"><label for="tag_wishlist" id="tag_wishlist_text">Items on your wishlist</label>
+						<input type="checkbox" id="tag_wishlist" data-setting="tag_wishlist"><label for="tag_wishlist" id="tag_wishlist_text" data-locale-text="options.wishlist">Items on your wishlist</label>
 					</li>
 					<li class="settings_color">
-						<input type="color" id="tag_wishlist_color" class="colorbutton">
-						<button id="tag_wishlist_default" class="btn">Default</button>
+						<input type="color" id="tag_wishlist_color" data-setting="tag_wishlist_color" class="colorbutton">
+						<button id="tag_wishlist_default" class="btn" data-locale-text="theworddefault">Default</button>
 					</li>
 				</div>
 				<div>
 					<li class="settings_check">
-						<input type="checkbox" id="tag_coupon"><label for="tag_coupon" id="tag_coupon_text">Items with coupons</label>
+						<input type="checkbox" id="tag_coupon" data-setting="tag_coupon"><label for="tag_coupon" id="tag_coupon_text" data-locale-text="options.coupon">Items with coupons</label>
 					</li>
 					<li class="settings_color">
-						<input type="color" id="tag_coupon_color" class="colorbutton">
-						<button id="tag_coupon_default" class="btn">Default</button>
+						<input type="color" id="tag_coupon_color" data-setting="tag_coupon_color" class="colorbutton">
+						<button id="tag_coupon_default" class="btn" data-locale-text="theworddefault">Default</button>
 					</li>
 				</div>
 				<div>
 					<li class="settings_check">
-						<input type="checkbox" id="tag_inv_gift"><label for="tag_inv_gift" id="tag_gift_text">Items stored as gift</label>
+						<input type="checkbox" id="tag_inv_gift" data-setting="tag_inv_gift"><label for="tag_inv_gift" id="tag_gift_text" data-locale-text="options.gift">Items stored as gift</label>
 					</li>
 					<li class="settings_color">
-						<input type="color" id="tag_inv_gift_color" class="colorbutton">
-						<button id="tag_inv_gift_default" class="btn">Default</button>
+						<input type="color" id="tag_inv_gift_color" data-setting="tag_inv_gift_color" class="colorbutton">
+						<button id="tag_inv_gift_default" class="btn" data-locale-text="theworddefault">Default</button>
 					</li>
 				</div>
 				<div>
 					<li class="settings_check">
-						<input type="checkbox" id="tag_inv_guestpass"><label for="tag_inv_guestpass" id="tag_guest_text">Items you have a guest pass for</label>
+						<input type="checkbox" id="tag_inv_guestpass" data-setting="tag_inv_guestpass"><label for="tag_inv_guestpass" id="tag_guest_text" data-locale-text="options.guest">Items you have a guest pass for</label>
 					</li>
 					<li class="settings_color">
-						<input type="color" id="tag_inv_guestpass_color" class="colorbutton">
-						<button id="tag_inv_guestpass_default" class="btn">Default</button>
+						<input type="color" id="tag_inv_guestpass_color" data-setting="tag_inv_guestpass_color" class="colorbutton">
+						<button id="tag_inv_guestpass_default" class="btn" data-locale-text="theworddefault">Default</button>
 					</li>
 				</div>
 				<div>
 					<li class="settings_check">
-						<input type="checkbox" id="tag_notinterested"><label for="tag_notinterested" id="tag_notinterested_text">Items marked not interested</label>
+						<input type="checkbox" id="tag_notinterested" data-setting="tag_notinterested"><label for="tag_notinterested" id="tag_notinterested_text" data-locale-text="options.notinterested">Items marked not interested</label>
 					</li>
 					<li class="settings_color">
-						<input type="color" id="tag_notinterested_color" class="colorbutton">
-						<button id="tag_notinterested_default" class="btn">Default</button>
+						<input type="color" id="tag_notinterested_color" data-setting="tag_notinterested_color" class="colorbutton">
+						<button id="tag_notinterested_default" class="btn" data-locale-text="theworddefault">Default</button>
 					</li>
 				</div>
 				<div>
 					<li class="settings_check">
-						<input type="checkbox" id="tag_short"><label for="tag_short" id="tag_short_text">Use short tags to save space</label>
+						<input type="checkbox" id="tag_short" data-setting="tag_short"><label for="tag_short" id="tag_short_text" data-locale-text="options.tags_short">Use short tags to save space</label>
 					</li>
 				</div>
-				<li class="header" id="hide_text">Hide</li>
-				<li><input type="checkbox" id="hide_owned"><label for="hide_owned" id="hide_owned_text">Items you own in search results</label></li>
-				<li><input type="checkbox" id="hidetmsymbols"><label for="hidetmsymbols" id="hidetmsymbols_text">Trademark and Copyright symbols in game titles</label></li>
-				<li><input type="checkbox" id="hideinstallsteambutton"><label for="hideinstallsteambutton" id="store_hide_install_text">Hide "Install Steam" button</label></li>
-				<li><input type="checkbox" id="hideaboutmenu"><label for="hideaboutmenu" id="store_hide_about_menu">Hide "About" link</label></li>
-				<li class="header" id="language_text">Language</li>				
-				<li><input type="checkbox" id="showlanguagewarning"><label for="showlanguagewarning" id="store_show_languagewarning_text">Show warning if browsing in a language other than</label>
-					<select id="warning_language">
+				<li class="header" id="hide_text" data-locale-text="options.hide">Hide</li>
+				<li><input type="checkbox" id="hide_owned" data-setting="hide_owned"><label for="hide_owned" id="hide_owned_text" data-locale-text="options.hide_owned">Items you own in search results</label></li>
+				<li><input type="checkbox" id="hidetmsymbols" data-setting="hidetmsymbols"><label for="hidetmsymbols" id="hidetmsymbols_text" data-locale-text="options.hidetmsymbols">Trademark and Copyright symbols in game titles</label></li>
+				<li><input type="checkbox" id="hideinstallsteambutton" data-setting="hideinstallsteambutton"><label for="hideinstallsteambutton" id="store_hide_install_text" data-locale-text="options.hide_install">Hide "Install Steam" button</label></li>
+				<li><input type="checkbox" id="hideaboutmenu" data-setting="hideaboutmenu"><label for="hideaboutmenu" id="store_hide_about_menu" data-locale-text="options.hide_about">Hide "About" link</label></li>
+				<li class="header" id="language_text" data-locale-text="language">Language</li>
+				<li><input type="checkbox" id="showlanguagewarning" data-setting="showlanguagewarning"><label for="showlanguagewarning" id="store_show_languagewarning_text" data-locale-text="options.showlanguagewarning">Show warning if browsing in a language other than</label>
+					<select id="warning_language" data-setting="showlanguagewarninglanguage" data-locale-text="showlanguagewarninglanguage">
 						<option value="English">English</option>
 						<option value="Bulgarian">български</option>
 						<option value="Czech">čeština</option>
@@ -188,61 +188,62 @@
 						<option value="Ukrainian">Українська</option>
 					</select>
 				</li>
-				<li class="header" id="homepage_text">Homepage</li>
-				<li><label for="homepage_default_tab" id="homepage_default_tab_text">Default homepage tab:</label>
-					<select id="homepage_tab_selection">
-						<option value="remember">Remember Previous</option>
-						<option value="tab_newreleases_content_trigger">Popular New Releases</option>
-						<option value="es_allreleases">All New Releases</option>
-						<option value="tab_topsellers_content_trigger">Top Sellers</option>
-						<option value="tab_upcoming_content_trigger">Upcoming</option>
-						<option value="tab_specials_content_trigger">Specials</option>
-						<option value="es_popular">Popular</option>
+				<li class="header" id="homepage_text" data-locale-text="options.homepage">Homepage</li>
+				<li><label for="homepage_default_tab" id="homepage_default_tab_text" data-locale-text="options.homepage_default_tab">Default homepage tab</label>
+					<select id="homepage_tab_selection" data-setting="homepage_tab_selection">
+						<option value="remember" data-locale-text="options.homepage_default_tab_remember">Remember Previous</option>
+						<option value="tab_newreleases_content_trigger" data-locale-text="options.homepage_default_tab_newreleases">Popular New Releases</option>
+						<option value="es_allreleases" data-locale-text="options.homepage_default_tab_allreleases">All New Releases</option>
+						<option value="tab_topsellers_content_trigger" data-locale-text="options.homepage_default_tab_topsellers">Top Sellers</option>
+						<option value="tab_upcoming_content_trigger" data-locale-text="options.homepage_default_tab_upcoming">Upcoming</option>
+						<option value="tab_specials_content_trigger" data-locale-text="options.homepage_default_tab_specials">Specials</option>
+						<option value="es_popular" data-locale-text="popular">Popular</option>
 					</select>
 				</li>
-				<li class="header" id="store_general">General</li>
-				<li><input type="checkbox" id="replaceaccountname"><label for="replaceaccountname" id="store_replace_account_name">Replace account name with community name</label></li>
-				<li><input type="checkbox" id="showfakeccwarning"><label for="showfakeccwarning" id="header_showfakeccwarning_text">Show warning if browsing in non-account region</label></li>
-				<li><input type="checkbox" id="send_age_info"><label for="send_age_info" id="send_age_info_text">Automatically send age verification when requested</label></li>
-				<li><input type="checkbox" id="html5video"><label for="html5video" id="html5video_text">Show videos using HTML5 instead of Flash</label></li>
-				<li><input type="checkbox" id="contscroll"><label for="contscroll" id="contscroll_text">Enable continuous scrolling of search results</label></li>
-				<li><input type="checkbox" id="showdrm"><label for="showdrm" id="store_drm_text">Show 3rd party DRM warnings</label><a href="http://enhancedsteam.com/featuredetail.php?id=3" class="help"></a></li>
-				<li><input type="checkbox" id="showacrtag"><label for="showacrtag" id="store_acrtag_text">Show warnings on items where cross region trading is disabled</label></li>
-				<li><input type="checkbox" id="showmcus"><label for="showmcus" id="store_metacritic_text">Show Metacritic user scores</label><a href="http://enhancedsteam.com/featuredetail.php?id=10" class="help"></a></li>
-				<li><input type="checkbox" id="showhltb"><label for="showhltb" id="store_hltb_text">Show HowLongToBeat.com information</label></li>
-				<li><input type="checkbox" id="showsteamdb"><label for="showsteamdb" id="store_steamdb_text">Show SteamDB links</label></li>
-				<li><input type="checkbox" id="showastatslink"><label for="showastatslink" id="store_astatslink_text">Show AStats link on app pages</label></li>
-				<li><input type="checkbox" id="showpcgw"><label for="showpcgw" id="store_pcgw_text">Show PCGamingWiki links</label></li>
-				<li><input type="checkbox" id="showclient"><label for="showclient" id="store_client_text">Show Steam Client links</label></li>
-				<li><input type="checkbox" id="showsteamcardexchange"><label for="showsteamcardexchange" id="store_steamcards_text">Show SteamCardExchange links on store pages</label></li>
-				<li><input type="checkbox" id="showwsgf"><label for="showwsgf" id="store_wsgf_text">Show WSGF (Widescreen) info</label><a href="http://enhancedsteam.com/featuredetail.php?id=15" class="help"></a></li>
-				<li><input type="checkbox" id="show_steamchart_info"><label for="show_steamchart_info" id="store_steamchart_info_text">Show SteamCharts.com info</label></li>
-				<li><input type="checkbox" id="show_steamspy_info"><label for="show_steamspy_info" id="store_steamspy_info_text">Show steamspy.com info</label></li>
-				<li><input type="checkbox" id="show_package_info"><label for="show_package_info" id="store_package_info_text">Show package info for all apps</label></li>
-				<li><input type="checkbox" id="show_sysreqcheck"><label for="show_sysreqcheck" id="show_sysreqcheck_text">Show button to check system requirements on app pages (Experimental!)</label></li>
-				<li><input type="checkbox" id="show_carousel_descriptions"><label for="show_carousel_descriptions" id="store_carousel_descriptions_text">Show app descriptions on storefront carousel</label><a href="http://enhancedsteam.com/featuredetail.php?id=26" class="help"></a></li>
-				<li><input type="checkbox" id="show_early_access"><label for="show_early_access" id="show_early_access_text">Show Early Access image banners</label>
-				<li><input type="checkbox" id="show_alternative_linux_icon"><label for="show_alternative_linux_icon" id="show_alternative_linux_icon_text">Show alternative Linux icon</label>
-				<li><input type="checkbox" id="show_itad_button"><label for="show_itad_button" id="show_itad_button_text">Show menu option to sync data to IsThereAnyDeal.com</label>
-				<li><input type="checkbox" id="skip_got_steam"><label for="skip_got_steam" id="skip_got_steam_text">Skip the 'Got Steam?' window</label>
+				<li class="header" id="store_general" data-locale-text="options.general">General</li>
+				<li><input type="checkbox" id="replaceaccountname" data-setting="replaceaccountname"><label for="replaceaccountname" id="store_replace_account_name" data-locale-text="options.replace_account_name">Replace account name with community name</label></li>
+				<li><input type="checkbox" id="showfakeccwarning" data-setting="showfakeccwarning"><label for="showfakeccwarning" id="header_showfakeccwarning_text" data-locale-text="options.show_regionwarning">Show warning if browsing in non-account region</label></li>
+				<li><input type="checkbox" id="send_age_info" data-setting="send_age_info"><label for="send_age_info" id="send_age_info_text" data-locale-text="options.send_age_info">Automatically send age verification when requested</label></li>
+				<li><input type="checkbox" id="html5video" data-setting="html5video"><label for="html5video" id="html5video_text" data-locale-text="options.html5video">Show videos using HTML5 instead of Flash</label></li>
+				<li><input type="checkbox" id="contscroll" data-setting="contscroll"><label for="contscroll" id="contscroll_text" data-locale-text="options.contscroll">Enable continuous scrolling of search results</label></li>
+				<li><input type="checkbox" id="showdrm" data-setting="showdrm"><label for="showdrm" id="store_drm_text" data-locale-text="options.drm">Show 3rd party DRM warnings</label><a href="http://enhancedsteam.com/featuredetail.php?id=3" class="help"></a></li>
+				<li><input type="checkbox" id="showacrtag" data-setting="show_acrtag_info"><label for="showacrtag" id="store_acrtag_text" data-locale-text="options.acrtag">Show warnings on items where cross region trading is disabled</label></li>
+				<li><input type="checkbox" id="showclient" data-setting="showclient"><label for="showclient" id="store_client_text" data-locale-text="options.showclient">Show Steam Client links</label></li>
+				<li><input type="checkbox" id="show_package_info" data-setting="show_package_info"><label for="show_package_info" id="store_package_info_text" data-locale-text="options.show_package_info">Show package info for all apps</label></li>
+				<li><input type="checkbox" id="show_sysreqcheck" data-setting="show_sysreqcheck"><label for="show_sysreqcheck" id="show_sysreqcheck_text" data-locale-text="options.show_sysreqcheck">Show button to check system requirements on app pages (Experimental!)</label></li>
+				<li><input type="checkbox" id="show_carousel_descriptions" data-setting="show_carousel_descriptions"><label for="show_carousel_descriptions" id="store_carousel_descriptions_text" data-locale-text="options.carousel_description">Show app descriptions on storefront carousel</label><a href="http://enhancedsteam.com/featuredetail.php?id=26" class="help"></a></li>
+				<li><input type="checkbox" id="show_early_access" data-setting="show_early_access"><label for="show_early_access" id="show_early_access_text" data-locale-text="options.show_early_access_text">Show Early Access image banners</label>
+				<li><input type="checkbox" id="show_alternative_linux_icon" data-setting="show_alternative_linux_icon"><label for="show_alternative_linux_icon" id="show_alternative_linux_icon_text" data-locale-text="options.show_alternative_linux_icon">Show alternative Linux icon</label>
+				<li><input type="checkbox" id="skip_got_steam" data-setting="skip_got_steam"><label for="skip_got_steam" id="skip_got_steam_text" data-locale-text="options.skip_got_steam">Skip the 'Got Steam?' window</label>
+				<li class="header" id="store_general_thirdparty">Options for information from 3rd party sites</li>
+				<li><input type="checkbox" id="showmcus" data-setting="showmcus"><label for="showmcus" id="store_metacritic_text" data-locale-text="options.metacritic">Show Metacritic user scores</label><a href="http://enhancedsteam.com/featuredetail.php?id=10" class="help"></a></li>
+				<li><input type="checkbox" id="showhltb" data-setting="showhltb"><label for="showhltb" id="store_hltb_text" data-locale-text="options.hltb">Show HowLongToBeat.com information</label></li>
+				<li><input type="checkbox" id="showsteamdb" data-setting="showsteamdb"><label for="showsteamdb" id="store_steamdb_text" data-locale-text="options.steamdb">Show SteamDB links</label></li>
+				<li><input type="checkbox" id="showastatslink" data-setting="showastatslink"><label for="showastatslink" id="store_astatslink_text" data-locale-text="options.show_astatslink">Show AStats link on app pages</label></li>
+				<li><input type="checkbox" id="showpcgw" data-setting="showpcgw"><label for="showpcgw" id="store_pcgw_text" data-locale-text="options.pcgw">Show PCGamingWiki links</label></li>
+				<li><input type="checkbox" id="showwsgf" data-setting="showwsgf"><label for="showwsgf" id="store_wsgf_text" data-locale-text="options.wsgf">Show WSGF (Widescreen) info</label><a href="http://enhancedsteam.com/featuredetail.php?id=15" class="help"></a></li>
+				<li><input type="checkbox" id="showsteamcardexchange" data-setting="showsteamcardexchange"><label for="showsteamcardexchange" id="store_steamcards_text" data-locale-text="options.store_steamcards">Show SteamCardExchange links on store pages</label></li>
+				<li><input type="checkbox" id="show_steamchart_info" data-setting="show_steamchart_info"><label for="show_steamchart_info" id="store_steamchart_info_text" data-locale-text="options.show_steamchart_info">Show SteamCharts.com info</label></li>
+				<li><input type="checkbox" id="show_steamspy_info" data-setting="show_steamspy_info"><label for="show_steamspy_info" id="store_steamspy_info_text" data-locale-text="options.show_steamspy_info">Show steamspy.com info</label></li>
+				<li><input type="checkbox" id="show_itad_button" data-setting="show_itad_button"><label for="show_itad_button" id="show_itad_button_text" data-locale-text="itad.option">Show menu option to sync data to IsThereAnyDeal.com</label>
 				</ul>
 			</div>
 
 			<div id="maincontent_price" class="content" style="display: none">
 				<ul>
-					<li class="header" id="store_lowestprice_header">Price History Information</li>
+					<li class="header" id="store_lowestprice_header" data-locale-text="options.lowestprice_header">Price History Information</li>
 					<li>
-						<input type="checkbox" id="showlowestprice"><label for="showlowestprice" id="store_lowestprice_text">Show</label>
+						<input type="checkbox" id="showlowestprice" data-setting="showlowestprice"><label for="showlowestprice" id="store_lowestprice_text" data-locale-text="options.lowestprice">Show</label>
 						<a href="http://enhancedsteam.com/featuredetail.php?id=5" class="help"></a>
 					</li>
 					<li>
-						<input type="checkbox" id="showlowestprice_onwishlist"><label for="showlowestprice_onwishlist" id="store_lowestprice_onwishlist_text">Show on Wishlist</label>
+						<input type="checkbox" id="showlowestprice_onwishlist" data-setting="showlowestprice_onwishlist"><label for="showlowestprice_onwishlist" id="store_lowestprice_onwishlist_text" data-locale-text="options.lowestprice_onwishlist">Show on Wishlist</label>
 					</li>
 					<li>
-						<input type="checkbox" id="showlowestpricecoupon"><label for="showlowestpricecoupon" id="store_lowestprice_coupon_text">Include coupon codes in price comparison</label>
+						<input type="checkbox" id="showlowestpricecoupon" data-setting="showlowestpricecoupon"><label for="showlowestpricecoupon" id="store_lowestprice_coupon_text" data-locale-text="options.lowestprice_coupon">Include coupon codes in price comparison</label>
 					</li>
 					<li>
-						<input type="checkbox" id="stores_all"><label for="stores_all" id="lowestprice_stores_all_text">Compare all stores</label>
+						<input type="checkbox" id="stores_all" data-setting="showallstores"><label for="stores_all" id="lowestprice_stores_all_text" data-locale-text="options.stores_all">Compare all stores</label>
 					</li>
 					<table id="store_stores" style="display: none" border=0>
 						<tr>
@@ -271,14 +272,14 @@
 							<td><input type="checkbox" id="gamesplanet"><label for="gamesplanet">GamesPlanet</label></td>
 						</tr>
 						<tr>
-							<td><input type="checkbox" id="newegg"><label for="newegg">Newegg</label></td>							
+							<td><input type="checkbox" id="newegg"><label for="newegg">Newegg</label></td>
 							<td><input type="checkbox" id="nuuvem"><label for="nuuvem">Nuuvem</label></td>
 							<td><input type="checkbox" id="dlgamer"><label for="dlgamer">DLGamer</label></td>
 						</tr>
-						<tr>							
+						<tr>
 							<td><input type="checkbox" id="dotemu"><label for="dotemu">DotEmu</label></td>
 							<td><input type="checkbox" id="indiegamestand"><label for="indiegamestand">IndieGameStand</label></td>
-							<td><input type="checkbox" id="squenix"><label for="squenix">Square Enix</label></td>							
+							<td><input type="checkbox" id="squenix"><label for="squenix">Square Enix</label></td>
 						</tr>
 						<tr>
 							<td><input type="checkbox" id="gamesrepublic"><label for="gamesrepublic">GamesRepublic</label></td>
@@ -299,8 +300,8 @@
 					<table>
 						<tr>
 						<li id="view_price_li">
-						<label id="viewprice_text">View in</label>
-						<select id="override_price">
+						<label id="viewprice_text"><span data-locale-text="view_in">View in</span>:</label>
+						<select id="override_price" data-setting="override_price">
 							<option value="auto">Auto-detect</option>
 							<option value="USD">USD</option>
 							<option value="GBP">GBP</option>
@@ -337,151 +338,151 @@
 						</li>
 						</tr>
 					</table>
-					<li class="header" id="store_regionalprice_header">Regional Price Comparison</li>
+					<li class="header" id="store_regionalprice_header" data-locale-text="options.regional_price">Regional Price Comparison</li>
 					<li id="regional_price_li">
-						<label id="showregionalprice_text">Show regional price comparison</label>
-						<select id="regional_price_on">
-							<option value="mouse">on Price Mouseover</option>
-							<option value="always">Always</option>
-							<option value="off">Never</option>
+						<label id="showregionalprice_text" data-locale-text="options.regional_price_on">Show regional price comparison</label>
+						<select id="regional_price_on" data-setting="showregionalprice">
+							<option value="mouse" data-locale-text="options.regional_price_mouse">on Price Mouseover</option>
+							<option value="always" data-locale-text="always">Always</option>
+							<option value="off" data-locale-text="never">Never</option>
 						</select>
 					</li>
-					<li id="regional_price_hideworld"><input type="checkbox" id="regional_hideworld"><label for="regional_hideworld" id="regional_hideworld_text">Hide globe indicator</label></li>			
+					<li id="regional_price_hideworld"><input type="checkbox" id="regional_hideworld" data-setting="regional_hideworld"><label for="regional_hideworld" id="regional_hideworld_text" data-locale-text="options.regional_hideworld">Hide globe indicator</label></li>
 					<div id='region_selects'>
-						<div style='margin-top: 15px; margin-left: 32px;'><button id="add_another_region" class="btn">Add</button><button id="reset_countries" class="btn">Default</button></div>
+						<div style='margin-top: 15px; margin-left: 32px;'><button id="add_another_region" data-locale-text="options.add_another_region" class="btn">Add</button><button id="reset_countries" class="btn" data-locale-text="theworddefault">Default</button></div>
 					</div>
 				</ul>
 			</div>
 
 			<div id="maincontent_community" class="content" style="display: none">
 				<ul>
-					<li class="header" id="community_market">Market</li>
+					<li class="header" id="community_market" data-locale-text="options.market">Market</li>
 					<li>
-						<input type="checkbox" id="showmarkettotal"><label for="showmarkettotal" id="market_total_text">Show transaction summary on Market</label>
+						<input type="checkbox" id="showmarkettotal" data-setting="showmarkettotal"><label for="showmarkettotal" id="market_total_text" data-locale-text="options.market_total">Show transaction summary on Market</label>
 						<a href="http://enhancedsteam.com/featuredetail.php?id=16" class="help"></a>
 					</li>
 					<li>
-						<input type="checkbox" id="hideactivelistings"><label for="hideactivelistings" id="hideactivelistings_text">Hide all active listings on Market homepage by default</label>
+						<input type="checkbox" id="hideactivelistings" data-setting="hideactivelistings"><label for="hideactivelistings" id="hideactivelistings_text" data-locale-text="options.hideactivelistings">Hide all active listings on Market homepage by default</label>
 					</li>
-					<li class="header" id="community_inventory">Inventory</li>					
+					<li class="header" id="community_inventory" data-locale-text="options.inventory">Inventory</li>
 					<li>
-						<input type="checkbox" id="quickinv"><label for="quickinv" id="quickinv_text">Show Quick Sale buttons on Steam Community items in inventory</label><a id="show_quickinv_diff">(Customize)</a>
+						<input type="checkbox" id="quickinv" data-setting="quickinv"><label for="quickinv" id="quickinv_text" data-locale-text="options.quickinv">Show Quick Sale buttons on Steam Community items in inventory</label> (<a id="show_quickinv_diff" data-locale-text="customize">Customize</a>)
 					</li>
 					<li id="quickinv_opt">
-						<label for="quickinv_diff" id="quickinv_diff_text">Quick Sale modifier:</label><input type="text" id="quickinv_diff" class="textbox"><button id="quickinv_default" class="btn">Default</button>
+						<label for="quickinv_diff" id="quickinv_diff_text" data-locale-text="options.quickinv_diff">Quick Sale modifier:</label><input type="text" id="quickinv_diff" data-setting="quickinv_diff" class="textbox"><button id="quickinv_default" class="btn" data-locale-text="theworddefault">Default</button>
 					</li>
 					<li>
-						<input type="checkbox" id="show1clickgoo"><label for="show1clickgoo" id="show1clickgoo_text">Show "1-Click turn into Gems..." button on applicable inventory items</label>
+						<input type="checkbox" id="show1clickgoo" data-setting="show1clickgoo"><label for="show1clickgoo" id="show1clickgoo_text" data-locale-text="options.show1clickgoo">Show "1-Click turn into Gems..." button on applicable inventory items</label>
 					</li>
 					<li>
-						<input type="checkbox" id="showinvnav"><label for="showinvnav" id="inventory_nav_text">Show advanced navigation on inventory page</label>
+						<input type="checkbox" id="showinvnav" data-setting="showinvnav"><label for="showinvnav" id="inventory_nav_text" data-locale-text="options.inventory_nav_text">Show advanced navigation on inventory page</label>
 					</li>
-					<li class="header" id="community_profile">Profile</li>
+					<li class="header" id="community_profile" data-locale-text="options.profile">Profile</li>
 					<li>
-						<input type="checkbox" id="showsteamrepapi"><label for="showsteamrepapi" id="steamrep_api_text">Show SteamRep status on profile pages</label>						
+						<input type="checkbox" id="showsteamrepapi" data-setting="showsteamrepapi"><label for="showsteamrepapi" id="steamrep_api_text" data-locale-text="options.steamrepapi">Show SteamRep status on profile pages</label>
 					</li>
 					<li>
-						<input type="checkbox" id="showesbg"><label for="showesbg" id="es_background_text">Set custom background on "Edit Profile" screen</label>
+						<input type="checkbox" id="showesbg" data-setting="showesbg"><label for="showesbg" id="es_background_text" data-locale-text="options.es_bg">Set custom background on "Edit Profile" screen</label>
 						<a href="http://enhancedsteam.com/featuredetail.php?id=17" class="help"></a>
 					</li>
 					<li>
-						<input type="checkbox" id="profile_permalink"><label for="profile_permalink" id="profile_permalink_text">Show permalink on profiles</label>
+						<input type="checkbox" id="profile_permalink" data-setting="profile_permalink"><label for="profile_permalink" id="profile_permalink_text" data-locale-text="options.profile_permalink">Show permalink on profiles</label>
 					</li>
-				<div id="profile_link_text">Show profile links to:</div><a href="http://enhancedsteam.com/featuredetail.php?id=21" class="help"></a>
+				<div id="profile_link_text" data-locale-text="options.profile_links">Show profile links to</div>:<a href="http://enhancedsteam.com/featuredetail.php?id=21" class="help"></a>
 				<ul id="profile_links">
 					<li>
-						<input type="checkbox" id="profile_steamrep"><label for="profile_steamrep"><img src="img/ico/steamrep.png" class="site_icon site_icon_gray" /><img src="img/ico/steamrep_col.png" class="site_icon profile_link_icon_background site_icon_col" />SteamRep</label>
+						<input type="checkbox" id="profile_steamrep" data-setting="profile_steamrep"><label for="profile_steamrep"><img src="img/ico/steamrep.png" class="site_icon site_icon_gray" /><img src="img/ico/steamrep_col.png" class="site_icon profile_link_icon_background site_icon_col" />SteamRep</label>
 					</li>
 					<li>
-						<input type="checkbox" id="profile_steamdbcalc"><label for="profile_steamdbcalc"><img src="img/ico/steamdb.png" class="site_icon" />SteamDB</label>
+						<input type="checkbox" id="profile_steamdbcalc" data-setting="profile_steamdbcalc"><label for="profile_steamdbcalc"><img src="img/ico/steamdb.png" class="site_icon" />SteamDB</label>
 					</li>
 					<li>
-						<input type="checkbox" id="profile_steamgifts"><label for="profile_steamgifts"><img src="img/ico/steamgifts.png" class="site_icon site_icon_gray" /><img src="img/ico/steamgifts_col.png" class="site_icon site_icon_col" />SteamGifts</label>
+						<input type="checkbox" id="profile_steamgifts" data-setting="profile_steamgifts"><label for="profile_steamgifts"><img src="img/ico/steamgifts.png" class="site_icon site_icon_gray" /><img src="img/ico/steamgifts_col.png" class="site_icon site_icon_col" />SteamGifts</label>
 					</li>
 					<li>
-						<input type="checkbox" id="profile_astats"><label for="profile_astats"><img src="img/ico/achievementstats.png" class="site_icon site_icon_gray" /><img src="img/ico/achievementstats_col.png" class="site_icon site_icon_col" />Achievement Stats</label>
+						<input type="checkbox" id="profile_astats" data-setting="profile_astats"><label for="profile_astats"><img src="img/ico/achievementstats.png" class="site_icon site_icon_gray" /><img src="img/ico/achievementstats_col.png" class="site_icon site_icon_col" />Achievement Stats</label>
 					</li>
 					<li>
-						<input type="checkbox" id="profile_backpacktf"><label for="profile_backpacktf"><img src="img/ico/backpacktf.png" class="site_icon site_icon_gray" /><img src="img/ico/backpacktf_col.png" class="site_icon site_icon_col" />Backpack.tf</label>
+						<input type="checkbox" id="profile_backpacktf" data-setting="profile_backpacktf"><label for="profile_backpacktf"><img src="img/ico/backpacktf.png" class="site_icon site_icon_gray" /><img src="img/ico/backpacktf_col.png" class="site_icon site_icon_col" />Backpack.tf</label>
 					</li>
 					<li>
-						<input type="checkbox" id="profile_astatsnl"><label for="profile_astatsnl"><img src="img/ico/astatsnl.png" class="site_icon site_icon_gray" /><img src="img/ico/astatsnl_col.png" class="site_icon site_icon_col" />AStats.nl</label>
+						<input type="checkbox" id="profile_astatsnl" data-setting="profile_astatsnl"><label for="profile_astatsnl"><img src="img/ico/astatsnl.png" class="site_icon site_icon_gray" /><img src="img/ico/astatsnl_col.png" class="site_icon site_icon_col" />AStats.nl</label>
 					</li>
 				</ul>
 				<li>
-					<label id="show_profile_link_images_text">Profile link images:</label>&nbsp;
-					<select id="profile_link_images_dropdown">
-						<option value="gray" id="profile_link_images_gray">Grayscale</option>
-						<option value="color" id="profile_link_images_color">Colored</option>
-						<option value=false id="profile_link_images_none">None</option>
+					<label id="show_profile_link_images_text" data-locale-text="options.profile_link_images">Profile link images</label>&nbsp;
+					<select id="profile_link_images_dropdown" data-setting="show_profile_link_images">
+						<option value="gray" id="profile_link_images_gray" data-locale-text="options.profile_link_images_gray">Grayscale</option>
+						<option value="color" id="profile_link_images_color" data-locale-text="options.profile_link_images_color">Colored</option>
+						<option value=false id="profile_link_images_none" data-locale-text="options.profile_link_images_none">None</option>
 					</select>
 				</li>
-					<li class="header" id="community_greenlight">Greenlight</li>
+					<li class="header" id="community_greenlight" data-locale-text="options.greenlight">Greenlight</li>
 					<li>
-						<input type="checkbox" id="showgreenlightbanner"><label for="showgreenlightbanner" id="greenlight_banner_text">Replace Steam Greenlight banner</label>
+						<input type="checkbox" id="showgreenlightbanner" data-setting="showgreenlightbanner"><label for="showgreenlightbanner" id="greenlight_banner_text" data-locale-text="options.greenlight_banner">Replace Steam Greenlight banner</label>
 						<a href="http://enhancedsteam.com/featuredetail.php?id=14" class="help"></a>
 					</li>
 					<li>
-						<input type="checkbox" id="dynamicgreenlight"><label for="dynamicgreenlight" id="dynamicgreenlight_text">Use dynamic data while browsing Greenlight</label>
+						<input type="checkbox" id="dynamicgreenlight" data-setting="dynamicgreenlight"><label for="dynamicgreenlight" id="dynamicgreenlight_text" data-locale-text="options.dynamicgreenlight">Use dynamic data while browsing Greenlight</label>
 					</li>
 					<li>
-						<input type="checkbox" id="remembergreenlightfilter"><label for="remembergreenlightfilter" id="remembergreenlightfilter_text">Remember Greenlight filter options</label>
+						<input type="checkbox" id="remembergreenlightfilter" data-setting="remembergreenlightfilter"><label for="remembergreenlightfilter" id="remembergreenlightfilter_text" data-locale-text="options.remembergreenlightfilter">Remember Greenlight filter options</label>
 					</li>
 					<li>
-						<input type="checkbox" id="endlessscrollinggreenlight"><label for="endlessscrollinggreenlight" id="endlessscrollinggreenlight_text">Enable continuous scrolling of Greenlight search results</label>
+						<input type="checkbox" id="endlessscrollinggreenlight" data-setting="endlessscrollinggreenlight"><label for="endlessscrollinggreenlight" id="endlessscrollinggreenlight_text" data-locale-text="options.endlessscrollinggreenlight">Enable continuous scrolling of Greenlight search results</label>
 					</li>
-					<li class="header" id="community_general">General</li>
+					<li class="header" id="community_general" data-locale-text="options.general">General</li>
 					<li>
-						<input type="checkbox" id="showtotal"><label for="showtotal" id="total_spent_text">Show total spent on account page</label>
+						<input type="checkbox" id="showtotal" data-setting="showtotal"><label for="showtotal" id="total_spent_text" data-locale-text="options.total_spent">Show total spent on account page</label>
 						<a href="http://enhancedsteam.com/featuredetail.php?id=6" class="help"></a>
 					</li>
 					<li>
-						<input type="checkbox" id="showallachievements"><label for="showallachievements" id="allachievements_text">Show achievement stats on "All Games" page</label>
+						<input type="checkbox" id="showallachievements" data-setting="showallachievements"><label for="showallachievements" id="allachievements_text" data-locale-text="options.showallachievements">Show achievement stats on "All Games" page</label>
 						<a href="http://enhancedsteam.com/featuredetail.php?id=18" class="help"></a>
 					</li>
 					<li>
-						<input type="checkbox" id="showcomparelinks"><label for="showcomparelinks" id="showcomparelinks_text">Show "Compare" links for achievements on friend activity feed</label>
+						<input type="checkbox" id="showcomparelinks" data-setting="showcomparelinks"><label for="showcomparelinks" id="showcomparelinks_text" data-locale-text="options.showcomparelinks">Show "Compare" links for achievements on friend activity feed</label>
 					</li>
 					<li>
-						<input type="checkbox" id="hidespamcomments"><label for="hidespamcomments" id="hidespamcomments_text">Hide spam comments from Workshop &amp; profiles</label><a id="show_spamcommentregex">(Customize)</a>
+						<input type="checkbox" id="hidespamcomments" data-setting="hidespamcomments"><label for="hidespamcomments" id="hidespamcomments_text" data-locale-text="options.hidespamcomments">Hide spam comments from Workshop &amp; profiles</label> (<a id="show_spamcommentregex" data-locale-text="customize">Customize</a>)
 					</li>
 					<li id="spamcommentregex_list">
-						<label for="spamcommentregex" id="spamcommentregex_text">Regular Expression string:</label><input type="text" id="spamcommentregex" class="textbox"><button id="spamcommentregex_default" class="btn">Default</button>
+						<label for="spamcommentregex" id="spamcommentregex_text" data-locale-text="options.spamcommentregex">Regular Expression string:</label><input type="text" id="spamcommentregex" data-setting="spamcommentregex" class="textbox"><button id="spamcommentregex_default" class="btn" data-locale-text="theworddefault">Default</button>
 					</li>
 					<li>
-						<input type="checkbox" id="steamcardexchange"><label for="steamcardexchange" id="steamcardexchange_text">Show SteamCardExchange links on badges</label>
+						<input type="checkbox" id="steamcardexchange" data-setting="steamcardexchange"><label for="steamcardexchange" id="steamcardexchange_text" data-locale-text="options.steamcardexchange">Show SteamCardExchange links on badges</label>
 						<a href="http://enhancedsteam.com/featuredetail.php?id=19" class="help"></a>
 					</li>
 					<li>
-						<input type="checkbox" id="wlbuttoncommunityapp"><label for="wlbuttoncommunityapp" id="wlbuttoncommunityapp_text">Show "Add to Wishlist" button on community app hubs</label>
+						<input type="checkbox" id="wlbuttoncommunityapp" data-setting="wlbuttoncommunityapp"><label for="wlbuttoncommunityapp" id="wlbuttoncommunityapp_text" data-locale-text="options.wlbuttoncommunityapp">Show "Add to Wishlist" button on community app hubs</label>
 					</li>
 					<li>
-						<input type="checkbox" id="removeguideslanguagefilter"><label for="removeguideslanguagefilter" id="removeguideslanguagefilter_text">Don't automatically filter guides by user language</label>
+						<input type="checkbox" id="removeguideslanguagefilter" data-setting="removeguideslanguagefilter"><label for="removeguideslanguagefilter" id="removeguideslanguagefilter_text" data-locale-text="options.removeguideslanguagefilter">Don't automatically filter guides by user language</label>
 					</li>
 					<li>
-						<input type="checkbox" id="disablelinkfilter"><label for="disablelinkfilter" id="disablelinkfilter_text">Disable confirmation when accessing external sites</label>
+						<input type="checkbox" id="disablelinkfilter" data-setting="disablelinkfilter"><label for="disablelinkfilter" id="disablelinkfilter_text" data-locale-text="options.disablelinkfilter">Disable confirmation when accessing external sites</label>
 					</li>
 			</ul>
 
 		</div>
 
 		<div id="maincontent_news" class="content" style="display: none">
-			<div id="changelog_text" class="header">Changelog:</div>
+			<div id="changelog_text" class="header" data-locale-text="options.changelog">Changelog:</div>
 		</div>
 
 		<div id="maincontent_about" class="content" style="display: none">
-			<div id="es_about_text"></div>
+			<div id="es_about_text" data-locale-html="options.about_text"></div>
 		</div>
 
 		<div id="maincontent_credits" class="content" style="display: none">
 			<ul class="credits">
-				<li class="header" id="programming_text">Programming</li>
+				<li class="header" id="programming_text" data-locale-text="programming">Programming</li>
 				<li>Jason '<a href="http://steamcommunity.com/profiles/76561198040672342" id="jshackles_steam">jshackles</a>' Shackles</li>
 				<li>Ben '<a href="http://steamcommunity.com/profiles/76561198000198761" id="smashman_steam">smash.mn</a>' Williams</li>
 				<li></li>
-				<li><div id="view_all"><a href='https://github.com/jshackles/Enhanced_Steam/graphs/contributors'>VIEW ALL</a></div></li>
+				<li><div id="view_all"><a href='https://github.com/jshackles/Enhanced_Steam/graphs/contributors' data-locale-text="view_all">VIEW ALL</a></div></li>
 			</ul>
-			<div class="header" id="translation_text">Translation</div>
+			<div class="header" id="translation_text" data-locale-text="translation">Translation</div>
 			<table class="translation">
 				<tr>
 					<td class="language brazilian">Portuguese-Brazil:</td>
@@ -561,7 +562,7 @@
 				</tr>
 				<tr>
 					<td class="language spanish">Spanish:</td>
-					<td>#SG# Sharkiller, 00HiZaM, Alien8, Digmin3, ItsMarukka, Kharn Nete, MλXX [PA-D], Profesor Pistacho, Robotnick, Silence, \\Vince, giraam, kalprestito, kulapik, p0tat0, wasakakero, xGreg</td>
+					<td>#SG# Sharkiller, 00HiZaM, Alien8, Digmin3, ItsMarukka, Kharn Nete, MλXX [PA-D], Profesor Pistacho, Robotnick, Silence, \Vince, giraam, kalprestito, kulapik, p0tat0, wasakakero, xGreg</td>
 				</tr>
 				<tr>
 					<td class="language swedish">Swedish:</td>
@@ -587,8 +588,8 @@
 		</div>
 
 		<div id="footer">
-			<div><a href="http://www.enhancedsteam.com" id="foot_link">Enhanced Steam Extension</a></div><span id="author_info">by jshackles</span>
-			<div><button id="reset" class="btn">Reset options</button></div>
+			<div><a href="http://www.enhancedsteam.com" id="foot_link" data-locale-text="options.foot_link">Enhanced Steam Extension</a></div><span id="author_info" data-locale-text="options.author_info">by jshackles</span>
+			<div><button id="reset" class="btn" data-locale-text="options.reset">Reset options</button></div>
 		</div>
 	</div>
 </body>

--- a/options.html
+++ b/options.html
@@ -245,7 +245,7 @@
 					<li>
 						<input type="checkbox" id="stores_all" data-setting="showallstores"><label for="stores_all" id="lowestprice_stores_all_text" data-locale-text="options.stores_all">Compare all stores</label>
 					</li>
-					<table id="store_stores" style="display: none" border=0>
+					<table id="store_stores" style="display: none" border="0">
 						<tr>
 							<td><input type="checkbox" id="steam"><label for="steam">Steam</label></td>
 							<td><input type="checkbox" id="amazonus"><label for="amazonus">Amazon US</label></td>
@@ -439,6 +439,9 @@
 					<li>
 						<input type="checkbox" id="showallachievements" data-setting="showallachievements"><label for="showallachievements" id="allachievements_text" data-locale-text="options.showallachievements">Show achievement stats on "All Games" page</label>
 						<a href="http://enhancedsteam.com/featuredetail.php?id=18" class="help"></a>
+					</li>
+					<li>
+						<input type="checkbox" id="showachinstore" data-setting="showachinstore"><label for="showachinstore" id="showachinstore_text" data-locale-text="achievements.option">Show achievements on store pages</label>
 					</li>
 					<li>
 						<input type="checkbox" id="showcomparelinks" data-setting="showcomparelinks"><label for="showcomparelinks" id="showcomparelinks_text" data-locale-text="options.showcomparelinks">Show "Compare" links for achievements on friend activity feed</label>


### PR DESCRIPTION
*Many steps have been automated, code in options.js was cut by half*

- options under "General" tab that had something to do with 3rd party
sites were moved separately since the options list got quite big and
confusing
- redone the way settings are saved and initialized
- redone the way localized strings are inserted
- redone the way navigation tabs work to show their content
- removed unnecessary functions
- several minor touches

All these changes ammout to alot of repetitive code being removed making it easier to maintain.
Also adding an option is now much more easier, basically you add the HTML needed for the input and a new entry in "settings_defaults".