### PR TITLE
Adjusted font size so numbers don't overlap

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -98,7 +98,7 @@ img.platform_small, .platform_img {
 	padding-left: 15px;
 }
 .chart-stat span {
-	font-size: 2em;
+	font-size: 1.8em;
 	font-weight: 300;
 }
 


### PR DESCRIPTION
- under "Current Players" numbers overlap for games with many players
such as Dota 2