### PR TITLE
Activity page highlighting and link filter optimizations

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -1848,3 +1848,25 @@ input[type=checkbox].es_dlc_selection:checked + label {
 .es_faq_cards {
 	margin-top: 4px;
 }
+
+/***************************************
+ * Activity pages
+ * add_achievement_comparison_link()
+ **************************************/
+.blotter_block a.es_highlight {
+	color: rgba(255, 255, 255, 0.80);
+	padding: 1px 4px;
+	line-height: 20px;
+	white-space: nowrap;
+	box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.22);
+	text-shadow: 0 0 2px rgba(0, 0, 0, 0.80);
+}
+.es_achievement_compare {
+	font-size: 10px;
+	float: right;
+	margin-right: 6px;
+}
+.es_achievements {
+	margin-top: 0 !important;
+}
+

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -6917,7 +6917,7 @@ function start_friend_activity_highlights() {
 		var wishlistapps = data.rgWishlist;
 
 		// Get all appids and nodes from selectors
-		$(".blotter_block").not(".es_highlight_checked").addClass("es_highlight_checked").find("a").each(function (i, node) {
+		$(".blotter_block").not(".es_highlight_checked").addClass("es_highlight_checked").find("a").not(".blotter_gamepurchase_logo").each(function (i, node) {
 			var appid = get_appid(node.href);
 
 			if (appid && !$(node).hasClass("blotter_userstats_game")) {


### PR DESCRIPTION
- fixed a bug where the highlighting process would run over already
highlighted items
- apps text is highlighted diferently to make it easier to read
- in "add_achievement_comparison_link()" when requesting for the stats
page the required data is memoized so there are no more subsequent
request are for the same page
-  "add_achievement_comparison_link()" is only be called on owned apps
- added a mutation observer for discussion pages that load paginated
content via ajax when removal of links filtering is enabled