### PR TITLE
launch_random_button() revert to using ES API

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -8737,7 +8737,7 @@ function groups_leave_options() {
 	}
 }
 
-var owned_playable_apps = (function() {
+var owned_playable_promise = (function() {
 	var deferred = new $.Deferred();
 
 	var owned_playable_cache = getValue("owned_apps"),
@@ -8771,7 +8771,7 @@ function launch_random_button() {
 	$("#es_popup").append("<div class='hr'></div><a id='es_random_game' class='popup_menu_item' style='cursor: pointer;'>" + localized_strings.launch_random + "</a>");
 
 	$("#es_random_game").on("click", function() {
-		$.when.apply($, [owned_playable_apps]).done(function(data) {
+		$.when.apply($, [owned_playable_promise]).done(function(data) {
 			var games = data.response.games,
 				rand = games[Math.floor(Math.random() * games.length)];
 

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -8780,7 +8780,7 @@ function launch_random_button() {
 					var prompt = ShowConfirmDialog('" + localized_strings.play_game.replace("__gamename__", rand.name.replace("'", "").trim()) + "', '<img src=//cdn.akamai.steamstatic.com/steam/apps/" + rand.appid + "/header.jpg>', null, null, '" + localized_strings.visit_store + "'); \
 					prompt.done(function(result) {\
 						if (result == 'OK') { window.location.assign('steam://run/" + rand.appid + "'); }\
-						if (result == 'SECONDARY') { window.location.assign('//store.steampowered.com/app/" + rand + "'); }\
+						if (result == 'SECONDARY') { window.location.assign('//store.steampowered.com/app/" + rand.appid + "'); }\
 					});\
 				}"
 			);


### PR DESCRIPTION
There were some issues with owned apps returned from dynamic store data
where video didn't work properly and it would propose apps that are not
directly playable such as DLCs... So we go back to using the ES API for
providing the list with playable games.