### PR TITLE
Add prefix-free background gradient for the options page

### DIFF
--- a/css/options.css
+++ b/css/options.css
@@ -1,5 +1,7 @@
 body {
+	background: #000000; /* fallback */
 	background: -webkit-linear-gradient(top,  #000000 0%,#0b1821 100%); /* Chrome10+,Safari5.1+ */
+	background: linear-gradient(to bottom, #000000 0%, #0b1821 100%); /* Standard */
 	margin-left: 0px;
 	color: #efffef;
 	font-family:"Arial", sans-serif;


### PR DESCRIPTION
Firefox doesn't support the (webkit) prefixed `linear-gradient`, so was rendering the options page with no background. I've added the standard/un-prefixed syntax to fix this. Chrome and Safari no longer need the prefixed version either, but I'm not sure what browser versions you're supporting, so I've left the prefixed version in as a fallback.