### PR TITLE
Wrap string in single quotes

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -5013,7 +5013,7 @@ function inventory_market_helper(response) {
 			$sideMarketActs.show().html("<img class='es_loading' src='//steamcommunity-a.akamaihd.net/public/images/login/throbber.gif' />");
 
 			// "View in market" link
-			html += '<div style="height: 24px;"><a href="//steamcommunity.com/market/listings/' + global_id + '/' + hash_name + '">' + localized_strings.view_in_market + '</a></div>';
+			html += '<div style="height: 24px;"><a href="//steamcommunity.com/market/listings/' + global_id + '/' + encodeURI(hash_name) + '">' + localized_strings.view_in_market + '</a></div>';
 
 			// Check if price is stored in data
 			if (dataLowest) {
@@ -5026,7 +5026,7 @@ function inventory_market_helper(response) {
 
 				$sideMarketActs.html(html);
 			} else {
-				get_http("//steamcommunity.com/market/priceoverview/?currency=" + currency_type_to_number(user_currency) + "&appid=" + global_id + "&market_hash_name=" + hash_name, function(txt) {
+				get_http("//steamcommunity.com/market/priceoverview/?currency=" + currency_type_to_number(user_currency) + "&appid=" + global_id + "&market_hash_name=" + encodeURI(hash_name), function(txt) {
 					var data = JSON.parse(txt);
 
 					if (data.success) {

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -5013,7 +5013,7 @@ function inventory_market_helper(response) {
 			$sideMarketActs.show().html("<img class='es_loading' src='//steamcommunity-a.akamaihd.net/public/images/login/throbber.gif' />");
 
 			// "View in market" link
-			html += "<div style='height: 24px;'><a href='//steamcommunity.com/market/listings/" + global_id + "/" + hash_name + "'>" + localized_strings.view_in_market + "</a></div>";
+			html += '<div style="height: 24px;"><a href="//steamcommunity.com/market/listings/' + global_id + '/' + hash_name + '">' + localized_strings.view_in_market + '</a></div>';
 
 			// Check if price is stored in data
 			if (dataLowest) {


### PR DESCRIPTION
- Fixes #1122

Note:
@jshackles all strings should be wrapped in single quotes to avoid such situations, I was lazy and let it _slide_ when I've recoded **inventory_market_helper()**.
However, instead of going through all code take your time if you can and setup a linter and include this rule (is pretty much the standard so I'd be surprised if is not already like that by default). It can be setup so it follows most of ES's coding style so there won't too many warnings but there are still a few more things that need to be changed for better standards.