### PR TITLE
#719 - Option to hide/remove "Empty Wishlist" button

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -120,6 +120,7 @@ var currency_promise = (function() {
 var is_signed_in = false;
 var profile_url = false;
 var profile_path = false;
+var should_Show_Wishlist_Button = true;
 
 var signed_in_promise = (function () {
 	var deferred = new $.Deferred();
@@ -1327,7 +1328,7 @@ function load_inventory() {
 }
 
 function add_empty_wishlist_buttons() {
-	if(is_signed_in) {
+	if(is_signed_in && should_Show_Wishlist_Button) {
 		var profile = $(".playerAvatar a")[0].href.replace(window.location.protocol + "//steamcommunity.com", "");
 		if (window.location.pathname.startsWith(profile)) {
 			var empty_buttons = $("<div class='btn_save' id='es_empty_wishlist'>" + localized_strings.empty_wishlist + "</div>");
@@ -2278,6 +2279,16 @@ function remove_about_menu() {
 		if (settings.hideaboutmenu === undefined) { settings.hideaboutmenu = false; storage.set({'hideaboutmenu': settings.hideaboutmenu}); }
 		if (settings.hideaboutmenu) {
 			$(".menuitem[href$='http://store.steampowered.com/about/']").remove();
+		}
+	});
+}
+
+// Remove the "Empty Wishlist" button at the bottom of the wishlist page
+function remove_empty_wishlist_button() {
+	storage.get(function(settings) {
+		if (settings.hideaboutemptywishlist === undefined) { settings.hideaboutemptywishlist = false; storage.set({'hideaboutemptywishlist': settings.hideaboutemptywishlist}); }
+		if (settings.hideaboutemptywishlist) {
+			should_Show_Wishlist_Button = false;
 		}
 	});
 }
@@ -9248,6 +9259,7 @@ $(document).ready(function(){
 			add_language_warning();
 			remove_install_steam_button();
 			remove_about_menu();
+			remove_empty_wishlist_button();
 			add_header_links();
 			process_early_access();
 			disable_link_filter();

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -1329,20 +1329,21 @@ function load_inventory() {
 function add_empty_wishlist_buttons() {
 	if(is_signed_in) {
 		storage.get(function(settings) {
-	 		if (settings.showemptywishlist === undefined) { 
-	 			settings.showemptywishlist = true; 
-	 			storage.set({'showemptywishlist': settings.showemptywishlist}); 
-	 		}
-	 		if (!settings.hideaboutemptywishlist) {
-	 			return;
-	 		}
-	 	});
-		var profile = $(".playerAvatar a")[0].href.replace(window.location.protocol + "//steamcommunity.com", "");
-		if (window.location.pathname.startsWith(profile)) {
-			var empty_buttons = $("<div class='btn_save' id='es_empty_wishlist'>" + localized_strings.empty_wishlist + "</div>");
-			$(".save_actions_enabled").filter(":last").after(empty_buttons);
-			$("#es_empty_wishlist").click(empty_wishlist);
-		}
+			if (settings.showemptywishlist === undefined) { 
+				settings.showemptywishlist = true; 
+				storage.set({'showemptywishlist': settings.showemptywishlist}); 
+			}
+			if (!settings.showemptywishlist) {
+				return;
+			}
+		
+			var profile = $(".playerAvatar a")[0].href.replace(window.location.protocol + "//steamcommunity.com", "");
+			if (window.location.pathname.startsWith(profile)) {
+				var empty_buttons = $("<div class='btn_save' id='es_empty_wishlist'>" + localized_strings.empty_wishlist + "</div>");
+				$(".save_actions_enabled").filter(":last").after(empty_buttons);
+				$("#es_empty_wishlist").click(empty_wishlist);
+			}
+		});
 	}
 }
 

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -120,7 +120,6 @@ var currency_promise = (function() {
 var is_signed_in = false;
 var profile_url = false;
 var profile_path = false;
-var should_Show_Wishlist_Button = true;
 
 var signed_in_promise = (function () {
 	var deferred = new $.Deferred();
@@ -1328,7 +1327,16 @@ function load_inventory() {
 }
 
 function add_empty_wishlist_buttons() {
-	if(is_signed_in && should_Show_Wishlist_Button) {
+	if(is_signed_in) {
+		storage.get(function(settings) {
+	 		if (settings.showemptywishlist === undefined) { 
+	 			settings.showemptywishlist = true; 
+	 			storage.set({'showemptywishlist': settings.showemptywishlist}); 
+	 		}
+	 		if (!settings.hideaboutemptywishlist) {
+	 			return;
+	 		}
+	 	});
 		var profile = $(".playerAvatar a")[0].href.replace(window.location.protocol + "//steamcommunity.com", "");
 		if (window.location.pathname.startsWith(profile)) {
 			var empty_buttons = $("<div class='btn_save' id='es_empty_wishlist'>" + localized_strings.empty_wishlist + "</div>");
@@ -2279,16 +2287,6 @@ function remove_about_menu() {
 		if (settings.hideaboutmenu === undefined) { settings.hideaboutmenu = false; storage.set({'hideaboutmenu': settings.hideaboutmenu}); }
 		if (settings.hideaboutmenu) {
 			$(".menuitem[href$='http://store.steampowered.com/about/']").remove();
-		}
-	});
-}
-
-// Remove the "Empty Wishlist" button at the bottom of the wishlist page
-function remove_empty_wishlist_button() {
-	storage.get(function(settings) {
-		if (settings.hideaboutemptywishlist === undefined) { settings.hideaboutemptywishlist = false; storage.set({'hideaboutemptywishlist': settings.hideaboutemptywishlist}); }
-		if (settings.hideaboutemptywishlist) {
-			should_Show_Wishlist_Button = false;
 		}
 	});
 }
@@ -9259,7 +9257,6 @@ $(document).ready(function(){
 			add_language_warning();
 			remove_install_steam_button();
 			remove_about_menu();
-			remove_empty_wishlist_button();
 			add_header_links();
 			process_early_access();
 			disable_link_filter();

--- a/js/options.js
+++ b/js/options.js
@@ -108,6 +108,7 @@ var settings_defaults = {
 	
 	"hideinstallsteambutton": false,
 	"hideaboutmenu": false,
+	"hideaboutemptywishlist": false,
 	"version_show": true,
 	"replaceaccountname": false,
 	"showfakeccwarning": true,

--- a/js/options.js
+++ b/js/options.js
@@ -108,7 +108,7 @@ var settings_defaults = {
 	
 	"hideinstallsteambutton": false,
 	"hideaboutmenu": false,
-	"hideaboutemptywishlist": false,
+	"showemptywishlist": true,
 	"version_show": true,
 	"replaceaccountname": false,
 	"showfakeccwarning": true,

--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -368,7 +368,7 @@
         "showspeechsearch": "Add speech input to search boxes",
         "profile_link_images_color": "Colored",
         "hide_about": "Hide \"About\" link",
-        "hide_empty_wishlist": "Hide \"Empty Wishlist\" button",
+        "show_empty_wishlist": "Show \"Empty Wishlist\" button",
         "inventory_nav_text": "Show advanced navigation on inventory page",
         "carousel_description": "Show app descriptions on storefront carousel",
         "market_total": "Show transaction summary on Market",

--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -368,6 +368,7 @@
         "showspeechsearch": "Add speech input to search boxes",
         "profile_link_images_color": "Colored",
         "hide_about": "Hide \"About\" link",
+        "hide_empty_wishlist": "Hide \"Empty Wishlist\" button",
         "inventory_nav_text": "Show advanced navigation on inventory page",
         "carousel_description": "Show app descriptions on storefront carousel",
         "market_total": "Show transaction summary on Market",

--- a/options.html
+++ b/options.html
@@ -155,7 +155,7 @@
 				<li><input type="checkbox" id="hidetmsymbols" data-setting="hidetmsymbols"><label for="hidetmsymbols" id="hidetmsymbols_text" data-locale-text="options.hidetmsymbols">Trademark and Copyright symbols in game titles</label></li>
 				<li><input type="checkbox" id="hideinstallsteambutton" data-setting="hideinstallsteambutton"><label for="hideinstallsteambutton" id="store_hide_install_text" data-locale-text="options.hide_install">Hide "Install Steam" button</label></li>
 				<li><input type="checkbox" id="hideaboutmenu" data-setting="hideaboutmenu"><label for="hideaboutmenu" id="store_hide_about_menu" data-locale-text="options.hide_about">Hide "About" link</label></li>
-				<li><input type="checkbox" id="hideaboutemptywishlist" data-setting="hideaboutemptywishlist"><label for="hideaboutemptywishlist" id="store_hide_empty_wishlist" data-locale-text="options.hide_empty_wishlist">Hide "Empty Wishlist" button</label></li>
+				<li><input type="checkbox" id="showemptywishlist" data-setting="showemptywishlist"><label for="showemptywishlist" id="store_hide_empty_wishlist" data-locale-text="options.show_empty_wishlist">Show "Empty Wishlist" button</label></li>
 				<li class="header" id="language_text" data-locale-text="language">Language</li>
 				<li><input type="checkbox" id="showlanguagewarning" data-setting="showlanguagewarning"><label for="showlanguagewarning" id="store_show_languagewarning_text" data-locale-text="options.showlanguagewarning">Show warning if browsing in a language other than</label>
 					<select id="warning_language" data-setting="showlanguagewarninglanguage" data-locale-text="showlanguagewarninglanguage">

--- a/options.html
+++ b/options.html
@@ -155,6 +155,7 @@
 				<li><input type="checkbox" id="hidetmsymbols" data-setting="hidetmsymbols"><label for="hidetmsymbols" id="hidetmsymbols_text" data-locale-text="options.hidetmsymbols">Trademark and Copyright symbols in game titles</label></li>
 				<li><input type="checkbox" id="hideinstallsteambutton" data-setting="hideinstallsteambutton"><label for="hideinstallsteambutton" id="store_hide_install_text" data-locale-text="options.hide_install">Hide "Install Steam" button</label></li>
 				<li><input type="checkbox" id="hideaboutmenu" data-setting="hideaboutmenu"><label for="hideaboutmenu" id="store_hide_about_menu" data-locale-text="options.hide_about">Hide "About" link</label></li>
+				<li><input type="checkbox" id="hideaboutemptywishlist" data-setting="hideaboutemptywishlist"><label for="hideaboutemptywishlist" id="store_hide_empty_wishlist" data-locale-text="options.hide_empty_wishlist">Hide "Empty Wishlist" button</label></li>
 				<li class="header" id="language_text" data-locale-text="language">Language</li>
 				<li><input type="checkbox" id="showlanguagewarning" data-setting="showlanguagewarning"><label for="showlanguagewarning" id="store_show_languagewarning_text" data-locale-text="options.showlanguagewarning">Show warning if browsing in a language other than</label>
 					<select id="warning_language" data-setting="showlanguagewarninglanguage" data-locale-text="showlanguagewarninglanguage">


### PR DESCRIPTION
Achieves feature #719.

Ideally, I wanted to just check the setting in the add_empty_wishlist_buttons function, however the settings do not appear to be available in that context. Alternatively, I wanted to call .remove() on the button in remove_empty_wishlist_button()... but the button is not on the page at time of that method invoking.

So, instead we're adding a flag.

Alternatively (if we didn't want the global var), we could add css to the page in 'remove_empty_wishlist_button'.