### PR TITLE
Exclude tags in store search

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -1987,6 +1987,21 @@ input[type=checkbox].es_dlc_selection:checked + label {
 	padding: 5px;
 }
 
+.es_input_text {
+	background-color: #2a3f5a;
+        color: #fff;
+    border: 1px solid #000;
+    border-radius: 3px;
+    box-shadow: 1px 1px 0px #45556c;
+    width: 200px;
+    padding: 5px;
+    margin: 5px;
+}
+
+.es_input_text.blur {
+	color:#62696e;
+}
+
 /***************************************
  * Global Achievements pages
  **************************************/

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -3320,6 +3320,71 @@ function endless_scrolling_greenlight() {
 	}
 }
 
+function add_exclude_tags_to_search() {
+
+		var tagfilter_divs = $('#TagFilter_Container')[0].children;
+		var tagfilter_exclude_divs = [];
+		$.each(tagfilter_divs, function(i,val) {
+			var exclude_item = $(`<div class="tab_filter_control " data-param="tags" data-value="-${this.dataset.value}" data-loc="${this.dataset.loc}">
+					<div class="tab_filter_control_checkbox"></div>
+					<span class="tab_filter_control_label">${this.dataset.loc}</span>
+					</div>`);
+			exclude_item.click(function() { 
+//			runInPageContext(function() {
+				var strValues = decodeURIComponent( $("#tags").val() );
+				var value = String(this.dataset.value);
+				if ( !$(this).hasClass( 'checked' ) )
+				{
+					var rgValues;
+					if( !strValues )
+						rgValues = [ value ];
+					else
+					{
+						rgValues = strValues.split(',');
+						if( $.inArray(value, rgValues) == -1 )
+							rgValues.push(value)
+					}
+
+					$("#tags").val( rgValues.join(',') );
+					$(this).addClass('checked');
+				}
+				else
+				{
+					var rgValues = strValues.split(',');
+					if( rgValues.indexOf(value) != -1 )
+						rgValues.splice( rgValues.indexOf(value), 1 );
+
+					$("#tags").val( rgValues.join(',') );
+					$(this).removeClass('checked');
+				}
+				runInPageContext(function() {AjaxSearchResults();});
+//			})
+			});
+		    tagfilter_exclude_divs.push(exclude_item);
+		});
+
+
+		var dom_item = `
+			<div class='block' id='es_tagfilter_exclude'>
+				<div class='block_header'>
+					<div>${localized_strings.exclude_tags}</div>
+				 </div>
+				 <div class='block_content block_content_inner'>
+					<div style='max-height: 150px; overflow: hidden;' id='es_tagfilter_exclude_container'></div>
+					<input type="text" id="es_tagfilter_exclude_suggest" class="blur es_input_text">				
+				</div>
+			</div>
+		`;
+
+
+		$("#advsearchform").find(".rightcol").prepend(dom_item);
+		$("#es_tagfilter_exclude_container").append(tagfilter_exclude_divs);
+		runInPageContext(function() {
+			$J( '#es_tagfilter_exclude_container' ).tableFilter({ maxvisible: 15, control: '#es_tagfilter_exclude_suggest', dataattribute: 'loc', 'defaultText': 'Search for more tags' });
+		});
+
+}
+
 function add_hide_buttons_to_search() {
 	storage.get(function(settings) {
 		if (settings.hide_owned === undefined) { settings.hide_owned = false; storage.set({'hide_owned': settings.hide_owned}); }
@@ -9509,6 +9574,7 @@ $(document).ready(function(){
 						case /^\/search\/.*/.test(path):
 							endless_scrolling();
 							add_hide_buttons_to_search();
+							add_exclude_tags_to_search();
 							break;
 
 						case /^\/sale\/.*/.test(path):

--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -239,6 +239,7 @@
     "show_wishlist_total": "Show wishlist Total",
     "tag_short": "Use short tags to save space",
     "no_price_data": "No price data available",
+    "exclude_tags": "Exclude tags",
     "achievements": {
         "option": "Show achievements on store pages",
         "achievements": "Achievements",


### PR DESCRIPTION
Added ability to exclude user tags in search.
This is based on the fact that negative tag numbers in the search url
are excluded, and the "Narrow by tag" box already includes all(?) tags for me to harvest. :)

I would have liked to add the box after the "Narrow by tag" box, but since it has no id it would have to be done by index or manual navigation through the DOM.
I considered that too flaky and prone to breaking so it's directly below the "hide elements" box. 
