### PR TITLE
dynamicstore_promise() cache fix

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -172,7 +172,7 @@ var dynamicstore_promise = (function () {
 			var accountidtext = $('script:contains("g_AccountID")').text() || "",
 				accountid = /g_AccountID = (\d+);/.test(accountidtext) ? accountidtext.match(/g_AccountID = (\d+);/)[1] : 0;
 
-			get_http("//store.steampowered.com/dynamicstore/userdata/" + (accountid ? "?id=" + accountid + "&v=" + dataVersion : "?v=" + last_updated), function(txt) {
+			get_http("//store.steampowered.com/dynamicstore/userdata/" + (accountid ? "?id=" + accountid + "&v=" + dataVersion : "?v=" + expire_time), function(txt) {
 				var data = JSON.parse(txt);
 				if (data && data.hasOwnProperty("rgOwnedApps") && !$.isEmptyObject(data.rgOwnedApps)) {
 					setValue("dynamicstore_data", data);


### PR DESCRIPTION
Fixed a bug where empty data was being returned even after the user logged in correctly due Valve's aggressive caching.