### PR TITLE
UPDATE: Steam wallet balance in header as option

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -2122,8 +2122,13 @@ function send_age_verification() {
 
 // Display Steam Wallet funds in header
 function add_wallet_balance_to_header() {
-	$("#global_action_menu").append("<div id='es_wallet' style='text-align:right; padding-right:12px; line-height: normal;'>");
-	$("#es_wallet").load('http://store.steampowered.com #header_wallet_ctn');
+	storage.get(function(settings) {
+		if (settings.add_wallet_balance === undefined) { settings.add_wallet_balance = true; storage.set({'add_wallet_balance': settings.add_wallet_balance}); }
+		if (settings.add_wallet_balance) {
+			$("#global_action_menu").append("<div id='es_wallet' style='text-align:right; padding-right:12px; line-height: normal;'>");
+			$("#es_wallet").load('//store.steampowered.com/about/ #header_wallet_ctn');
+		}
+	});
 }
 
 // Checks to see if the extension has been updated

--- a/js/options.js
+++ b/js/options.js
@@ -150,7 +150,8 @@ var settings_defaults = {
 	"profile_astatsnl": true,
 	"profile_permalink": true,
 	"steamcardexchange": true,
-	"purchase_dates": true
+	"purchase_dates": true,
+	"add_wallet_balance": true
 };
 
 // Saves options to localStorage

--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -337,6 +337,7 @@
         "friends_rec": "Items your friends have reviewed",
         "lowestprice_header": "Price History Information",
         "total_spent": "Show total spent on account page",
+        "add_wallet_balance": "Show Steam Wallet funds in header",
         "about_text": "<div class=\"header\">About <a href='http://www.enhancedsteam.com'>Enhanced Steam</a>:</div><p>Enhanced Steam is an Extension for Google Chrome that adds many new features to the Steam website.<p>Features include:<ul><li>Highlighting games you already own</li><li>Highlighting games on your wishlist</li><li>Correctly calculating bundle discounts based on games you already own</li><li>Showing you how much money you've spent on Steam for the lifetime of your account</li><li>Highlighting DLC you own on a game page</li><li>Fixing \"No Image Available\" game icons on your wishlist for any game or DLC</li><li>Pointing out titles with 3rd party DRM</li></ul><p>If you find this Extension useful, please consider donating.",
         "stores_all": "Compare all stores",
         "show_early_access_text": "Show Early Access image banners",

--- a/options.html
+++ b/options.html
@@ -441,6 +441,9 @@
 						<input type="checkbox" id="showtotal" data-setting="showtotal"><label for="showtotal" id="total_spent_text" data-locale-text="options.total_spent">Show total spent on account page</label>
 					</li>
 					<li>
+						<input type="checkbox" id="add_wallet_balance" data-setting="add_wallet_balance"><label for="add_wallet_balance" id="add_wallet_balance_text" data-locale-text="options.add_wallet_balance">Show Steam Wallet funds in header</label>
+					</li>
+					<li>
 						<input type="checkbox" id="showallachievements" data-setting="showallachievements"><label for="showallachievements" id="allachievements_text" data-locale-text="options.showallachievements">Show achievement stats on "All Games" page</label>
 					</li>
 					<li>


### PR DESCRIPTION
- made the display of Steam wallet balance in header an option
- the balance is pulled from store.steampowered.com/_about/_ as the page
is smaller and faster to load