### PR TITLE
FIX: #1210

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -2084,3 +2084,14 @@ input[type=checkbox].es_dlc_selection:checked + label {
 	margin-top: -4px !important;
 }
 
+/***************************************
+ * Users profiles
+ * add_profile_style()
+ **************************************/
+.holidayprofile .persona_name.persona_name_spacer {
+	pointer-events: none; /* fixes username and alias dropdown not being clickable */
+}
+.holidayprofile .profile_content {
+	margin-top: -66px !important;
+	padding-top: 24px !important;
+}


### PR DESCRIPTION
- fixes username and alias dropdown not being clickable while having "Holiday 2014" style enabled
- fixed a background spacing issue with the main content container
_before_
![aaa](https://cloud.githubusercontent.com/assets/3322834/20861727/e753ccca-b99f-11e6-81fc-b71e9e3f6c38.png)
_after_
![bb](https://cloud.githubusercontent.com/assets/3322834/20861728/e7e0a5e6-b99f-11e6-93bb-e3d6ce58d8a5.png)


