### PR TITLE
FIX: Multiple spaces between Quick and Instant sell buttons

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -5258,15 +5258,18 @@ function inventory_market_helper(response) {
 											if (market.highest_buy_order) {
 												$(thisItem).data("price-low", price_low);
 											}
-
-											$(thisItem).addClass("es-price-loaded");
-											// Add "Quick Sell" button
-											if (price_high > price_low) {
-												$("#es_quicksell" + item).attr("price", price_high).html("<span>" + localized_strings.quick_sell.replace("__amount__", formatCurrency(price_high, currency_number_to_type(wallet_currency))) + "</span>").show().before("<br class='es-btn-spacer'>");
-											}
-											// Add "Instant Sell" button
-											if (market.highest_buy_order) {
-												$("#es_instantsell" + item).attr("price", price_low).html("<span>" + localized_strings.instant_sell.replace("__amount__", formatCurrency(price_low, currency_number_to_type(wallet_currency))) + "</span>").show().before("<br class='es-btn-spacer'>");
+											// Fixes multiple buttons
+											//console.log($(".item.activeInfo").is($(thisItem)), $(".item.activeInfo").prop("id"), $(thisItem).prop("id"));
+											if ($(".item.activeInfo").is($(thisItem))) {
+												$(thisItem).addClass("es-price-loaded");
+												// Add "Quick Sell" button
+												if (price_high > price_low) {
+													$("#es_quicksell" + item).attr("price", price_high).html("<span>" + localized_strings.quick_sell.replace("__amount__", formatCurrency(price_high, currency_number_to_type(wallet_currency))) + "</span>").show().before("<br class='es-btn-spacer'>");
+												}
+												// Add "Instant Sell" button
+												if (market.highest_buy_order) {
+													$("#es_instantsell" + item).attr("price", price_low).html("<span>" + localized_strings.instant_sell.replace("__amount__", formatCurrency(price_low, currency_number_to_type(wallet_currency))) + "</span>").show().before("<br class='es-btn-spacer'>");
+												}
 											}
 										}).complete(function(){
 											$(thisItem).removeClass("es-loading");


### PR DESCRIPTION
A check was readded in order to fix this bug and another one where buttons with wrong prices would be shown for a few moments.
The bug manifests when clicking multiple items in inventory before one or more had a chance to finish loading the pricing information. When done loading the information is inserted without checking whether it belongs to the item currently selected.

_Video with the bug https://streamable.com/63ev_