### PR TITLE
FIX: Holiday profile style bug

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -2089,10 +2089,10 @@ input[type=checkbox].es_dlc_selection:checked + label {
  * Users profiles
  * add_profile_style()
  **************************************/
-.holidayprofile .persona_name.persona_name_spacer {
+.es_profile_style .holidayprofile .persona_name.persona_name_spacer {
 	pointer-events: none; /* fixes username and alias dropdown not being clickable */
 }
-.holidayprofile .profile_content {
+.es_profile_style .holidayprofile .profile_content {
 	margin-top: -66px !important;
 	padding-top: 24px !important;
 }

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -4259,6 +4259,7 @@ function add_profile_style() {
 			var txt = data.style;
 			var available_styles = ["clear", "green", "holiday2014", "orange", "pink", "purple", "red", "teal", "yellow", "blue"];
 			if ($.inArray(txt, available_styles) > -1) {
+				$("body").addClass("es_profile_style");
 				switch (txt) {
 					case "holiday2014":
 						$("head").append("<link rel='stylesheet' type='text/css' href='//steamcommunity-a.akamaihd.net/public/css/skin_1/holidayprofile.css'>");
@@ -4269,7 +4270,7 @@ function add_profile_style() {
 						});
 						break;
 					case "clear":
-						$("body").addClass("es_profile_style es_style_clear");
+						$("body").addClass("es_style_clear");
 						break;
 					default:
 						$("head").append("<link rel='stylesheet' type='text/css' href='" + chrome.extension.getURL("img/profile_styles/" + txt + "/style.css") + "'>");


### PR DESCRIPTION
- fixed a bug with profiles using the Holiday theme (not via ES). On
these profiles the theme graphics are not loaded or shown, instead the
default theme is still displayed, so we avoid adding the CSS fixes for
the theme,  otherwise it would break the default design.
_(Profile example: [https://steamcommunity.com/id/steamdb_wendy/](https://steamcommunity.com/id/steamdb_wendy/))_