### PR TITLE
keep_chat_scroll_at_bottom

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -2162,8 +2162,9 @@ input[type=checkbox].es_dlc_selection:checked + label {
 
 /***************************************
  * Chat page
+ * keep_chat_scroll_at_bottom()
  **************************************/
- @keyframes esNewChatMessageAppears {
+@keyframes esNewChatMessageAppears {
 	from {opacity: 0.99;}
 	to {opacity: 1;}
 }

--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -2160,3 +2160,14 @@ input[type=checkbox].es_dlc_selection:checked + label {
 	filter: brightness(350%);
 }
 
+/***************************************
+ * Chat page
+ **************************************/
+ @keyframes esNewChatMessageAppears {
+	from {opacity: 0.99;}
+	to {opacity: 1;}
+}
+.chat_message {
+	animation-duration: 0.001s;
+	animation-name: esNewChatMessageAppears;
+}

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -3033,6 +3033,13 @@ function chat_dropdown_options(in_chat) {
 	}
 }
 
+	document.addEventListener('animationstart', function(event) {
+		if (event.animationName == "esNewChatMessageAppears") {
+			$(".chat_dialog:not([style*='none']) .chat_dialog_scroll").scrollTop($(".chat_dialog:not([style*='none']) .chat_dialog_content_inner").height());
+		}
+	}, false);
+}
+
 function ingame_name_link() {
 	var $ingameAppIdSel = $("input[name='ingameAppID']");
 

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -3033,6 +3033,7 @@ function chat_dropdown_options(in_chat) {
 	}
 }
 
+function keep_chat_scroll_at_bottom() {
 	document.addEventListener('animationstart', function(event) {
 		if (event.animationName == "esNewChatMessageAppears") {
 			$(".chat_dialog:not([style*='none']) .chat_dialog_scroll").scrollTop($(".chat_dialog:not([style*='none']) .chat_dialog_content_inner").height());
@@ -9714,6 +9715,7 @@ $(document).ready(function(){
 
 						case /^\/chat\//.test(path):
 							chat_dropdown_options(true);
+							keep_chat_scroll_at_bottom();
 							break;
 
 						case /^\/(?:id|profiles)\/.+\/\b(home|myactivity|status)\b\/?$/.test(path):


### PR DESCRIPTION
Fix Valve's mistakes (c)

That is so annoying scroll chat by yourself when using web version, so I even fought my laziness and fixed it. This is a bit tricky way, but it works well, doesn't impact performance and needs only few strings of code to operate.

Tested in Chrome and Firefox. Should work in others too.