### PR TITLE
get_store_session() extra login check

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -7802,7 +7802,7 @@ var get_store_session = (function () {
 					}
 				} else {
 					get_http("//store.steampowered.com/about/", function(txt) {
-						sessionid = (txt.match(/g_sessionID = "(.+)"/i) || [])[1];
+						sessionid = (txt.match(/g_AccountID = [\d]{2,}/i) && txt.match(/g_sessionID = "(.+)"/i) || [])[1];
 
 						if (sessionid) {
 							chrome.storage.local.set({


### PR DESCRIPTION
- g_sessionID is still available even when logged out so we need to make sure we are logged into the Store (since getting randomly but temporarily logged out of Store is a common occurrence)