### PR TITLE
FIX: load_inventory() reponse when logged out

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -1309,7 +1309,7 @@ function load_inventory() {
 		return deferred.promise();
 	} else {
 		var deferred = new $.Deferred();
-		deferred.resolve();
+		deferred.reject();
 		return deferred.promise();
 	}
 }


### PR DESCRIPTION
- it resulted on functions being executed while the user was logged out and then errors are thrown