### PR TITLE
UPDATE: add_lowest_market_price() code

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -4863,10 +4863,6 @@ function add_lowest_market_price() {
 		var cc = getStoreRegionCountryCode(),
 			currency = currency_type_to_number(user_currency);
 
-		$("#my_market_selllistings_number").parents(".my_listing_section").addClass("es_selling");
-		$(".es_selling").find(".market_listing_table_header span:first").css("width", "200px");
-		$(".es_selling").find(".market_listing_table_header span:first").after("<span class='market_listing_right_cell market_listing_my_price'><span class='es_market_lowest_button'>" + localized_strings.lowest + "</span></span>");
-
 		var memoized_market_price = {};
 		function memoize_market_price(market_hash_name, data) {
 			if (!memoized_market_price.hasOwnProperty(market_hash_name)) {
@@ -4894,6 +4890,12 @@ function add_lowest_market_price() {
 		}
 
 		function add_lowest_market_price_data(section, item_id) {
+			if (!$(".es_selling").length) {
+				$("#my_market_selllistings_number").parents(".my_listing_section").addClass("es_selling");
+				$(".es_selling").find(".market_listing_table_header span:first").css("width", "200px");
+				$(".es_selling").find(".market_listing_table_header span:first").after("<span class='market_listing_right_cell market_listing_my_price'><span class='es_market_lowest_button'>" + localized_strings.lowest + "</span></span>");
+			}
+
 			$(".es_selling").find(".market_listing_row").each(function() {
 				$(this).find(".market_listing_edit_buttons:first").css("width", "200px");
 				if ($(this).find(".market_listing_es_lowest").length == 0) {
@@ -4952,7 +4954,7 @@ function add_lowest_market_price() {
 
 		add_lowest_market_price_data(".es_selling");
 
-		setMutationHandler(document, "#tabContentsMyActiveMarketListings_start", function(){
+		setMutationHandler(document, "#tabContentsMyActiveMarketListingsRows", function(){
 			add_lowest_market_price_data(".es_selling");
 
 			return true;


### PR DESCRIPTION
_Redone add_lowest_market_price() in order to address some issues and
make some optimizations._
- the requests for prices are no longer made all at once, but rather 5 at
a time. This helps avoid being blocked by Valve for too many concurent
requests
- the prices are memoized; if the price for an item was already pulled
it won't be requested again
- if a price request fails (due to being blocked for eg.) no subsequent
requests will be made
- fixed a bug which caused the price requests to be re-issued everytime
listings were sorted
- fixed a bug which caused ES to break while being logged out and viewing the market