### PR TITLE
UPDATE: Empty wishlist code

### DIFF
--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -181,6 +181,7 @@
     "mods": "Mods",
     "empty_wishlist": "Empty wishlist",
     "empty_wishlist_confirm": "Are you sure you want to empty your wishlist?\n\nThis action cannot be undone!",
+    "empty_wishlist_loading": "Emptying your wishlist, please wait...",
     "about": "About",
     "never": "Never",
     "coupon_available": "You have a coupon available!",


### PR DESCRIPTION
_Redone the functions for emptying the wishlist and ajax removal of apps
from wishlist_
- removal requeste are done in batches of 5 at a time, this helps avoid
browser limitations happening when attemptin to empty large wishlists
- the requests are done via store API, but if they fail due to many
requests it will fallback to using the old method
- Valve's more user friendly modal prompt is used to inform the user