### PR TITLE
FIX #1382 (Pricing history for games with bundles do not load)

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -1805,7 +1805,11 @@ function add_wishlist_pricehistory() {
 
 							// "Number of times this game has been in a bundle"
 							if (data["bundles"]["count"] > 0) {
-								line3 = "<br>" + localized_strings.bundle.bundle_count + ": " + data["bundles"]["count"] + ' (<a href="' + escapeHTML(data["urls"]["bundle_history"].toString()) + '" target="_blank">' + localized_strings.info + '</a>)';
+								line3 = "<br>" + localized_strings.bundle.bundle_count + ": " + data["bundles"]["count"];
+								var bundles_url = data["urls"]["bundle_history"];
+								if (typeof bundles_url === "string" && bundles_url.length > 0) {
+									line3 += ' (<a href="' + escapeHTML(bundles_url) + '" target="_blank">' + localized_strings.info + '</a>)';
+								}
 							}
 
 							if (line1 && line2) {
@@ -2577,7 +2581,11 @@ function show_pricing_history(appid, type) {
 
 								// "Number of times this game has been in a bundle"
 								if (data["bundles"]["count"] > 0) {
-									line3 = "<br>" + localized_strings.bundle.bundle_count + ": " + data["bundles"]["count"] + ' (<a href="' + escapeHTML(data["urls"]["bundles"].toString()) + '" target="_blank">' + localized_strings.info + '</a>)';
+									line3 = "<br>" + localized_strings.bundle.bundle_count + ": " + data["bundles"]["count"];
+									var bundles_url = data["urls"]["bundle_history"];
+									if (typeof bundles_url === "string" && bundles_url.length > 0) {
+										line3 += ' (<a href="' + escapeHTML(bundles_url) + '" target="_blank">' + localized_strings.info + '</a>)';
+									}
 								}
 
 								if (line1 && line2) {

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -1806,7 +1806,7 @@ function add_wishlist_pricehistory() {
 							// "Number of times this game has been in a bundle"
 							if (data["bundles"]["count"] > 0) {
 								line3 = "<br>" + localized_strings.bundle.bundle_count + ": " + data["bundles"]["count"];
-								var bundles_url = data["urls"]["bundle_history"];
+								var bundles_url = data["urls"]["bundles"] || data["urls"]["bundle_history"];
 								if (typeof bundles_url === "string" && bundles_url.length > 0) {
 									line3 += ' (<a href="' + escapeHTML(bundles_url) + '" target="_blank">' + localized_strings.info + '</a>)';
 								}
@@ -2582,7 +2582,7 @@ function show_pricing_history(appid, type) {
 								// "Number of times this game has been in a bundle"
 								if (data["bundles"]["count"] > 0) {
 									line3 = "<br>" + localized_strings.bundle.bundle_count + ": " + data["bundles"]["count"];
-									var bundles_url = data["urls"]["bundle_history"];
+									var bundles_url = data["urls"]["bundles"] || data["urls"]["bundle_history"];
 									if (typeof bundles_url === "string" && bundles_url.length > 0) {
 										line3 += ' (<a href="' + escapeHTML(bundles_url) + '" target="_blank">' + localized_strings.info + '</a>)';
 									}


### PR DESCRIPTION
Two step approach:

1. Validate the incoming response for the existence of the `data["urls"]["bundle_history"]` property before putting it into a link to avoid the error ("(Info)" link will be lost). In addition the `.toString()` call was removed as it should already be a string when returned from the API (correct me if I'm wrong here).
2. Use an alternative property `data["urls"]["bundles"]` found in the response to seemingly restore "(Info)" link functionality back to normal. `data["urls"]["bundle_history"]` is still checked if the new property doesn't exist or is empty.
----
Issue reference: #1382