### PR TITLE
Fixed regex extracting market item name from URI

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -7145,7 +7145,7 @@ function highlight_market_items() {
 				}
 
 				$.each($(".market_listing_row_link"), function(i, node) {
-					var current_market_name = (node.href.match(/market\/listings\/753\/(.+)(\?)?/) || [])[1];
+					var current_market_name = (node.href.match(/market\/listings\/753\/(.+?)(\?|$)/) || [])[1];
 
 					if (current_market_name && steamInvNamesList.hasOwnProperty(decodeURIComponent(current_market_name))) {
 						highlight_owned($(node).find("div").first()[0]);


### PR DESCRIPTION
When searching through the market place, any search term not in the item's name would be appended to the URI as ('?filter=term'). The regex to extract the name from the URI also extracted that part, with (.+) matching everything up to the end of the URI and (\?)? always matching zero question marks. The fixed regex instead matches non-greedily up to the first question mark or end-of-line, whichever comes first.