### PR TITLE
AStats non-schema-agnostic link

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -2849,7 +2849,7 @@ function add_community_profile_links() {
 				"name": "Backpack.tf",
 			},
 			"astatsnl": {
-				"link": `//astats.astats.nl/astats/User_Info.php?steamID64=${ steamID }`,
+				"link": `http://astats.astats.nl/astats/User_Info.php?steamID64=${ steamID }`,
 				"name": "AStats.nl",
 			}
 		};


### PR DESCRIPTION
Browsing **https**://steamcommunity.com will provide a link to **https**://astats.astats.nl in the sidebar leading to a blank page; leaving the impression it's down as it does not support https yet.

**Example:**
https://steamcommunity.com/id/luchaos/ 
leads to
https://astats.astats.nl/astats/User_Info.php?steamID64=76561197962872631
which will not load. (yet)

I'd reverse that as soon as AStats does support https (_https only, go!_) - until then this change makes it a bit more convenient to browse.