### PR TITLE
FIX: EA promise JSON parse fail

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -5921,12 +5921,12 @@ var ea_promise = (function() {
 	// Update cache in the background
 	if (last_updated < expire_time) {
 		// If no cache exists, pull the data from the website
-		get_http(protocol + "//api.enhancedsteam.com/early_access/", function(txt) {
-			early_access_data = JSON.parse(txt);
+		get_http(protocol + "//api.enhancedsteam.com/early_access/", function(early_access_data) {
 			setValue("ea_appids", early_access_data);
 			setValue("ea_appids_time", parseInt(Date.now() / 1000, 10));
+
 			deferred.resolve(early_access_data);
-		}).fail(function(){
+		}, { dataType: "json"} ).fail(function(){
 			deferred.reject();
 		});
 	}


### PR DESCRIPTION
- fixed a bug where JSON.parse() would fail and break ES if the returned data was not in JSON format

_(Early Access API would return 'Too many requests'(or something like that) and 503 errors. It was fixed by the time I've submitted this tho)_