### PR TITLE
Use HTTPS for ES API requests

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -457,7 +457,7 @@ var currencyConversion = (function() {
 		if (rates) {
 			deferred.resolveWith(rates);
 		} else {
-			var apiurl = protocol + "//api.enhancedsteam.com/currencydata/?base=" + (currency || user_currency);
+			var apiurl = "https://api.enhancedsteam.com/currencydata/?base=" + (currency || user_currency);
 			get_http(apiurl, function(txt) {
 				rates = JSON.parse(txt);
 				cache_set(currency || user_currency, rates);
@@ -599,7 +599,7 @@ var storePageData = (function() {
 			var all = parseInt($("#review_type_all").next().find(".user_reviews_count").text().replace(/\(|\)|\,/g, "")),
 				pos = parseInt($("#review_type_positive").next().find(".user_reviews_count").text().replace(/\(|\)|\,/g, "")),
 				stm = parseInt($("#purchase_type_steam").next().find(".user_reviews_count").text().replace(/\(|\)|\,/g, ""));
-			var apiurl = protocol + "//api.enhancedsteam.com/storepagedata/?appid=" + appid;
+			var apiurl = "https://api.enhancedsteam.com/storepagedata/?appid=" + appid;
 			if (all && pos && stm) apiurl += "&r_all=" + all + "&r_pos=" + pos + "&r_stm=" + stm;
 			if (metalink) apiurl += "&mcurl=" + metalink;
 			
@@ -653,7 +653,7 @@ var storePageDataCN = (function() {
 		if (data) {
 			deferred.resolveWith(data);
 		} else {
-			var apiurl = protocol + "//api.enhancedsteam.com/storepagedatacn/?appid=" + appid;
+			var apiurl = "https://api.enhancedsteam.com/storepagedatacn/?appid=" + appid;
 			get_http(apiurl, function(txt) {
 				data = JSON.parse(txt);
 				cache_set(appid, data);
@@ -702,7 +702,7 @@ var profileData = (function() {
 		if (data) {
 			deferred.resolveWith(data);
 		} else if (steamid) {
-			var apiurl = protocol + "//api.enhancedsteam.com/profiledata/?steam64=" + steamid;
+			var apiurl = "https://api.enhancedsteam.com/profiledata/?steam64=" + steamid;
 			get_http(apiurl, function(txt) {
 				data = JSON.parse(txt);
 				cache_set(steamid, data);
@@ -1782,7 +1782,7 @@ function add_wishlist_pricehistory() {
 					html = "<div class='es_lowest_price' id='es_price_" + id + "'><div class='gift_icon' id='es_line_chart_" + id + "'><img src='" + chrome.extension.getURL("img/line_chart.png") + "'></div><span id='es_price_loading_" + id + "'>" + localized_strings.loading + "</span>";
 					$(node).append(html);
 
-					get_http(protocol + "//api.enhancedsteam.com/pricev3/?appid=" + id + "&stores=" + storestring + "&cc=" + cc + "&coupon=" + settings.showlowestpricecoupon, function (txt) {
+					get_http("https://api.enhancedsteam.com/pricev3/?appid=" + id + "&stores=" + storestring + "&cc=" + cc + "&coupon=" + settings.showlowestpricecoupon, function (txt) {
 						var data = JSON.parse(txt);
 						if (data) {
 							var activates = "", line1 = "", line2 = "", line3 = "", html, recorded, lowest, lowesth;
@@ -2548,7 +2548,7 @@ function show_pricing_history(appid, type) {
 					subids += value.value + ",";
 				});
 
-				get_http(protocol + "//api.enhancedsteam.com/pricev3/?bundleid=" + bundleid + "&subs=" + subids + "&stores=" + storestring + "&cc=" + cc + "&appid=" + appid + "&coupon=" + settings.showlowestpricecoupon, function (txt) {
+				get_http("https://api.enhancedsteam.com/pricev3/?bundleid=" + bundleid + "&subs=" + subids + "&stores=" + storestring + "&cc=" + cc + "&appid=" + appid + "&coupon=" + settings.showlowestpricecoupon, function (txt) {
 					var price_data = JSON.parse(txt);
 					if (price_data) {
 						var bundles = [];
@@ -3034,7 +3034,7 @@ function add_twitch_info() {
 		var twitch_id = $(search).attr("href").match(/twitch\.tv\/(.+)/)[1];
 		if (twitch_id) {
 			twitch_id = twitch_id.replace(/\//g, "");
-			get_http(protocol + "//api.enhancedsteam.com/twitch/?channel=" + twitch_id, function (txt) {
+			get_http("https://api.enhancedsteam.com/twitch/?channel=" + twitch_id, function (txt) {
 				if (txt) {
 					var data = JSON.parse(txt);
 					if (data["streams"].length > 0) {
@@ -3230,7 +3230,7 @@ function wishlist_add_ratings() {
 	if (appsUpdateQueue.length) {
 		var update_time = parseInt(Date.now() / 1000, 10);
 
-		get_http(protocol + '//api.enhancedsteam.com/reviews/', function(data) {
+		get_http("https://api.enhancedsteam.com/reviews/", function(data) {
 			var review_data = JSON.parse(data);
 
 			$.each(review_data, function(appid, scores) {
@@ -5125,7 +5125,7 @@ function inventory_market_helper(response) {
 					if (dataCardsPrice) {
 						$sideMarketActsDiv.append(localized_strings.avg_price_3cards + ": " + dataCardsPrice + "<br>");
 					} else {
-						var api_url = protocol + "//api.enhancedsteam.com/market_data/average_card_price/?appid=" + appid + "&cur=" + user_currency.toLowerCase();
+						var api_url = "https://api.enhancedsteam.com/market_data/average_card_price/?appid=" + appid + "&cur=" + user_currency.toLowerCase();
 
 						get_http(api_url, function(price_data) {
 							var booster_price = formatCurrency(parseFloat(price_data,10) * 3);
@@ -5652,7 +5652,7 @@ function dlc_data_from_site(appid) {
 	if ($("div.game_area_dlc_bubble").length > 0) {
 		var appname = $(".apphub_AppName").html();
 		appname = encodeURIComponent(appname);
-		get_http(protocol + "//api.enhancedsteam.com/gamedata/?appid=" + appid + "&appname=" + appname, function (txt) {
+		get_http("https://api.enhancedsteam.com/gamedata/?appid=" + appid + "&appname=" + appname, function (txt) {
 			var data;
 			if (txt != "{\"dlc\":}}") {
 				data = JSON.parse(txt);
@@ -5755,7 +5755,7 @@ function dlc_data_for_dlc_page() {
 	window.setTimeout(function() {
 		$.each($("div.dlc_page_purchase_dlc"), function(j, node){
 			var appid = get_appid(node.href || $(node).find("a")[0].href) || get_appid_wishlist(node.id);
-			get_http(protocol + "//api.enhancedsteam.com/gamedata/?appid=" + appid, function (txt) {
+			get_http("https://api.enhancedsteam.com/gamedata/?appid=" + appid, function (txt) {
 				var data;
 				if (txt != "{\"dlc\":}}") {
 					data = JSON.parse(txt);
@@ -5986,7 +5986,7 @@ var ea_promise = (function() {
 	// Update cache in the background
 	if (last_updated < expire_time) {
 		// If no cache exists, pull the data from the website
-		get_http(protocol + "//api.enhancedsteam.com/early_access/", function(early_access_data) {
+		get_http("https://api.enhancedsteam.com/early_access/", function(early_access_data) {
 			setValue("ea_appids", early_access_data);
 			setValue("ea_appids_time", parseInt(Date.now() / 1000, 10));
 
@@ -7419,7 +7419,7 @@ function add_es_background_selection() {
 				$(".group_content_bodytext").before(html);
 				runInPageContext(function() { BindCommunityTooltip( $J('.formRowHint') ); });
 
-				get_http(protocol + "//api.enhancedsteam.com/profile-select-v2/?steam64=" + steam64, function (txt) {
+				get_http("https://api.enhancedsteam.com/profile-select-v2/?steam64=" + steam64, function (txt) {
 					var data = JSON.parse(txt);
 					var select_html = "<select name='es_background_gamename' id='es_background_gamename' class='gray_bevel dynInput'><option value='0' id='0'>" + localized_strings.noneselected + "</option>";
 					
@@ -7448,7 +7448,7 @@ function add_es_background_selection() {
 						} else {
 							$("#es_profile_background_current_name").after("<div class='es_loading'><img src='" + protocol + "//steamcommunity-a.akamaihd.net/public/images/login/throbber.gif'><span>"+ localized_strings.loading +"</div>");							
 
-							get_http(protocol + "//api.enhancedsteam.com/profile-select-v2-game/?appid=" + appid + "&steam64=" + steam64, function (txt) {
+							get_http("https://api.enhancedsteam.com/profile-select-v2-game/?appid=" + appid + "&steam64=" + steam64, function (txt) {
 								var bg_data = JSON.parse(txt);
 								$("#es_profile_background_current_name").after("<div id='es_background_selection'></div>");
 								select_html = "<select name='es_background' id='es_background' class='gray_bevel dynInput'>";
@@ -8256,7 +8256,7 @@ function add_gamecard_market_links(game) {
 		foil = /border=1/i.test(document.URL),
 		price_type = "price" + (user_currency != "USD" ? "_" + user_currency.toLowerCase() : "");
 
-	get_http(protocol + "//api.enhancedsteam.com/market_data/card_prices/?appid=" + game, function(txt) {
+	get_http("https://api.enhancedsteam.com/market_data/card_prices/?appid=" + game, function(txt) {
 		var data = JSON.parse(txt);
 
 		// Turn card names into keys, this way we no longer need to loop and search the data each and everytime
@@ -8330,7 +8330,7 @@ function add_badge_completion_cost() {
 
 			// Next, get the average card values
 			if (appids.length > 0) {
-				get_http(protocol + "//api.enhancedsteam.com/market_data/average_card_prices/?cur=" + user_currency.toLowerCase() + "&appids=" + appids.join(), function(json) {
+				get_http("https://api.enhancedsteam.com/market_data/average_card_prices/?cur=" + user_currency.toLowerCase() + "&appids=" + appids.join(), function(json) {
 					var data = JSON.parse(json);
 					$.each(nodes, function(index, value) {
 						var appid = value[0],
@@ -8373,7 +8373,7 @@ function add_badge_completion_cost() {
 
 			// Finally, do the foils
 			if (foil_appids.length > 0) {
-				get_http(protocol + "//api.enhancedsteam.com/market_data/average_card_prices/?cur=" + user_currency.toLowerCase() + "&foil=true&appids=" + foil_appids.join(), function(json) {
+				get_http("https://api.enhancedsteam.com/market_data/average_card_prices/?cur=" + user_currency.toLowerCase() + "&foil=true&appids=" + foil_appids.join(), function(json) {
 					var foil_data = JSON.parse(json);
 					$.each(foil_nodes, function(index, value) {
 						var appid = value[0],
@@ -8588,7 +8588,7 @@ function add_birthday_celebration(in_store) {
 	var obj = {};
 	storage.get(function(settings) {
 		if (settings[setting_name] === undefined) {
-			get_http(protocol + '//api.enhancedsteam.com/steamapi/GetPlayerSummaries/?steamids=' + is_signed_in, function (txt) {
+			get_http("https://api.enhancedsteam.com/steamapi/GetPlayerSummaries/?steamids=" + is_signed_in, function (txt) {
 				var data = JSON.parse(txt);
 				var timecreated = data["response"]["players"][0]["timecreated"];
 				obj[setting_name] = timecreated;
@@ -8623,7 +8623,7 @@ function add_acrtag_warning() {
 					
 					if (last_updated < expire_time) {
 						// if no cache exists, pull the data from the website
-						get_http(protocol + "//api.enhancedsteam.com/acrtag/", function(txt) {
+						get_http("https://api.enhancedsteam.com/acrtag/", function(txt) {
 							acrtag_subids = txt;
 							setValue("acrtag_subids", acrtag_subids);
 							setValue("acrtag_subids_time", parseInt(Date.now() / 1000, 10));
@@ -8819,7 +8819,7 @@ var owned_playable_promise = function() {
 
 	// Update cache if needed
 	if (last_updated < expire_time) {
-		get_http(protocol + "//api.enhancedsteam.com/steamapi/GetOwnedGames/?steamid=" + is_signed_in, function(txt) {
+		get_http("https://api.enhancedsteam.com/steamapi/GetOwnedGames/?steamid=" + is_signed_in, function(txt) {
 			var data = JSON.parse(txt);
 			if (data && data.hasOwnProperty("response")) {
 				setValue("owned_apps", data);


### PR DESCRIPTION
Since the ES API server seems to support HTTPS for all requests, this shouldn't change anything for most users, but it would greatly reduce conflicts with _HTTPS Everywhere_. I've tested this in Chrome for almost two weeks with _HTTPS Everywhere_ disabled to ensure it won't cause any problems for regular users.

Although some rare problems might persist for _HTTPS Everywhere_ users, I consider the three issues mentioned in my commit message (#1319, #1432, #1445) fixed, because this is probably the best we can get without Steam allowing HTTPS for all API requests (or us proxying them).

I'm not convinced the conflicts with _HTTPS Everywhere_ are our fault, but if we can easily fix (or at least improve) them, we should do so.