### PR TITLE
0 reviews NaN fix

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -3257,10 +3257,12 @@ function wishlist_add_ratings() {
 	}
 
 	function build_review(appid, scores, type) {
-		var percent = ((Math.floor(100 * (scores["p"] / scores["t"])) / 100) * 100).toFixed(),
-			score = (percent >= 70 ? "positive" : (percent >= 40 ? "mixed" : "negative"));
+		var percent = scores["t"] == 0 ? 0 : ((Math.floor(100 * (scores["p"] / scores["t"])) / 100) * 100).toFixed(),
+			score = (percent >= 70 ? "positive" : (percent >= 40 || scores["t"] == 0 ? "mixed" : "negative"));
 
-		var tooltip = localized_strings.review_summary
+		var tooltip = scores["t"] == 0 ?
+					localized_strings.review_summary_no_reviews :
+					localized_strings.review_summary
 						.replace("__percent__", percent + "%")
 						.replace("__num__", scores["t"].toLocaleString());
 

--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -250,6 +250,7 @@
     "user_score": "User Score",
     "user_reviews": "User reviews",
     "review_summary": "__percent__ of the __num__ user reviews for this game are positive.",
+    "review_summary_no_reviews": "No reviews for this game yet.",
     "market_popular_items_toggle": "Toggle live updating for Popular Items",
     "achievements": {
         "option": "Show achievement completion on store pages",


### PR DESCRIPTION
When game have 0 reviews it says NaN% and shows negative review image. I changed it to show 0%, displaying mixed review image and tooltip "No reviews for this game yet".
![problem](https://user-images.githubusercontent.com/22682876/31454643-bf3b9ea6-aebe-11e7-9b42-0e96325730d6.jpg)
![fix](https://user-images.githubusercontent.com/22682876/31454649-c156148c-aebe-11e7-8e35-9cb8c46887ca.jpg)
