### PR TITLE
Fix HTML parsing issues

### DIFF
--- a/options.html
+++ b/options.html
@@ -1,11 +1,12 @@
-<html>
-<script src="js/jQuery.min.js"></script>
-<script src="js/options.js"></script>
-<link href="css/options.css" rel="stylesheet" type="text/css">
-<link href="css/es_flags.css" rel="stylesheet" type="text/css">
-<link href="css/es_sites_links.css" rel="stylesheet" type="text/css">
-<meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
+	<script src="js/jQuery.min.js"></script>
+	<script src="js/options.js"></script>
+	<link href="css/options.css" rel="stylesheet" type="text/css">
+	<link href="css/es_flags.css" rel="stylesheet" type="text/css">
+	<link href="css/es_sites_links.css" rel="stylesheet" type="text/css">
+	<meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
 	<title>Enhanced Steam Options</title>
 	<base target="_blank">
 </head>
@@ -301,6 +302,7 @@
 					<li></li>
 					<table>
 						<tr>
+							<td>
 						<li id="view_price_li">
 						<label id="viewprice_text"><span data-locale-text="view_in">View in</span>:</label>
 						<select id="override_price" data-setting="override_price">
@@ -338,6 +340,7 @@
 							<option value="COP">COP</option>
 						</select>
 						</li>
+							</td>
 						</tr>
 					</table>
 					<li class="header" id="store_regionalprice_header" data-locale-text="options.regional_price">Regional Price Comparison</li>


### PR DESCRIPTION
This fixes HTML parsing issues that can be seen in Firefox when viewing the source of the options page.

Of course, the best way to prevent something like this happening in the future would be to switch the options page to [XHTML](https://developer.mozilla.org/en-US/docs/Glossary/XHTML).