### PR TITLE
Use https-qualified URLs for platform images in FireFox

### DIFF
--- a/css/enhancedsteam-firefox.css
+++ b/css/enhancedsteam-firefox.css
@@ -16,3 +16,15 @@
 #es_progress.error::-moz-progress-bar {
 	background-color: #B31414;
 }
+span.platform_img.steamplay {
+  background-image: url("https://steamstore-a.akamaihd.net/public/images/v6/icon_steamplay.png") !important;
+}
+span.platform_img.win {
+  background-image: url("https://steamstore-a.akamaihd.net/public/images/v6/icon_platform_win.png")  !important;
+}
+span.platform_img.mac {
+  background-image: url("https://steamstore-a.akamaihd.net/public/images/v6/icon_platform_mac.png")  !important;
+}
+span.platform_img.linux {
+  background-image: url("https://steamstore-a.akamaihd.net/public/images/v6/icon_platform_linux.png") !important;
+}


### PR DESCRIPTION
This is a port of https://github.com/jshackles/Enhanced_Steam_Firefox/pull/115 into the main Enhanced Steam repo, per @jshackles's comment in jshackles/Enhanced_Steam_Firefox#114:

> Since Mozilla keeps changing how these relative paths load, I believe your idea of manually specifying an https protocol sounds prudent. Feel free to create a pull request with these changes in enhancedsteam-firefox.css in the dev branch here: https://github.com/jshackles/Enhanced_Steam/tree/dev

@c12h did the work here, I'm just porting over the PR.