### PR TITLE
Updated wishlist sorting by price if discounted price has decimal separator

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -1452,7 +1452,7 @@ function add_wishlist_sorts() {
 					break;
 				case "price":
 					sort_wishlist(".price, .discount_final_price", sort_by, true, function(val){
-						return Number(val.replace(/\-/g, "0").replace(/[^0-9\.]+/g, "")) || 31337;
+						return Number(val.replace(/\-/g, "0").replace(/,/g, ".").replace(/[^0-9\.]+/g, "")) || 31337;
 					});
 					break;
 				case "score":


### PR DESCRIPTION
For most European countries sorting by price currently works incorrectly in wishlist if discounted price contains decimal separator (which is comma instead of dot), so if there are 2 games with discounted prices 75,5 and 100 accordingly, they will be sorted vice versa, because parsing function currently returns 755 instead of 75.5