### PR TITLE
Fixed wishlist sorting by price for Russian rubles

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -1484,7 +1484,7 @@ function add_wishlist_sorts() {
 					break;
 				case "price":
 					sort_wishlist(".price, .discount_final_price", sort_by, true, function(val){
-						return Number(val.replace(/\-/g, "0").replace(/,/g, ".").replace(/[^0-9\.]+/g, "")) || 31337;
+						return Number(val.replace(/\-/g, "0").replace(/,/g, ".").replace(/[^0-9\.]+\.?/g, "")) || 31337;
 					});
 					break;
 				case "score":


### PR DESCRIPTION
Hi @jshackles,

last pull request #1493 I created fixed issue for me as I have € as a currency, but my friend from Russia reported that issue still exists in his wishlist. Turned out they have '.' character in a currency display name (for instance, that's a valid price display - 161,85 pуб. ), so additional fix was required. Now I checked all the currencies there are, work as intended.