### PR TITLE
UPDATE: AStats schema agnostic link (revert)

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -2901,7 +2901,7 @@ function add_community_profile_links() {
 				"name": "Backpack.tf",
 			},
 			"astatsnl": {
-				"link": `http://astats.astats.nl/astats/User_Info.php?steamID64=${ steamID }`,
+				"link": `//astats.astats.nl/astats/User_Info.php?steamID64=${ steamID }`,
 				"name": "AStats.nl",
 			}
 		};


### PR DESCRIPTION
**As of today AStats has SSL and supports https links.** 

Browsing https://steamcommunity.com will link properly to https://astats.astats.nl again and work as intended.

As promised in https://github.com/jshackles/Enhanced_Steam/pull/1406, this reverts links back to being schema agnostic.