### PR TITLE
Update options.html

### DIFF
--- a/options.html
+++ b/options.html
@@ -217,7 +217,7 @@
 				<li><input type="checkbox" id="show_badge_progress" data-setting="show_badge_progress"><label for="show_badge_progress" id="show_badge_progress_text" data-locale-text="options.show_badge_progress">Show apps badge progress on store pages</label></li>
 				<li><input type="checkbox" id="show_alternative_linux_icon" data-setting="show_alternative_linux_icon"><label for="show_alternative_linux_icon" id="show_alternative_linux_icon_text" data-locale-text="options.show_alternative_linux_icon">Show alternative Linux icon</label>
 				<li><input type="checkbox" id="skip_got_steam" data-setting="skip_got_steam"><label for="skip_got_steam" id="skip_got_steam_text" data-locale-text="options.skip_got_steam">Skip the 'Got Steam?' window</label>
-				<li class="header" id="store_general_thirdparty">Options for information from 3rd party sites</li>
+				<li class="header" id="store_general_thirdparty" data-locale-text="options.store_general_thirdparty">Options for information from 3rd party sites</li>
 				<li><input type="checkbox" id="show_keylol_links" data-setting="show_keylol_links"><label for="show_keylol_links" id="store_keylol_text">Show Keylol links on app pages</label></li>
 				<li><input type="checkbox" id="showmcus" data-setting="showmcus"><label for="showmcus" id="store_metacritic_text" data-locale-text="options.metacritic">Show Metacritic user scores</label></li>
 				<li><input type="checkbox" id="showoc" data-setting="showoc"><label for="showoc" id="store_opencritic_text" data-locale-text="options.opencritic">Show Opencritic.com information</label></li>


### PR DESCRIPTION
Without it, the translations for the text „Options for information from 3rd party sites” are not read from the „localization” folder.