### PR TITLE
Add fullscreen screenshots button

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -1233,77 +1233,82 @@ input[type=checkbox].es_dlc_selection:checked + label {
  * App pages
  * add_fullscreen_screenshots_button()
  **************************************/
- .es_fullscreen_toggle {
- 	position: absolute;
- 	right: 18%;
- 	top: 0;
- }
- .es_fullscreen_toggle i {
- 	display: block;
- 	background-image: url('data:image/gif;base64,R0lGODlhEAAgAIABAP///////yH5BAEAAAEALAAAAAAQACAAAAJAjH+gC+jB1HNxpmqjnHVz31iQOIoh5D0Spmom+y0kypDaOWf2hVMNjLi9asNUTFZECpO9FjIDDLqOvyYvscsVAAA7');
- 	background-position: top left;
- 	width: 16px;
- 	height: 16px;
- 	margin: 5px;
- }
- .screenshot_popup_modal_content.es_fullscreen .es_fullscreen_toggle i {
- 	background-position: bottom left;
- }
- .screenshot_popup_modal_content.es_fullscreen {
- 	padding: 0;
- 	width: 100%; /* fullscreen fix for Chrome */
- 	height: 100%;
- }
- .screenshot_popup_modal_content.es_fullscreen .screenshot_popup_modal_title {
- 	/* position: absolute; */
- 	display: none;
- }
- .screenshot_popup_modal_content.es_fullscreen .screenshot_img_ctn > img {
- 	max-width: 100% !important;
- 	max-height: 100% !important;
- 	object-fit: scale-down;
- 	width: 100%;
- 	height: 100%;
- }
- .screenshot_popup_modal_content.es_fullscreen .screenshot_popup_modal_footer {
- 	position: absolute;
- 	width: 100%;
- 	bottom: 0;
- 	overflow: visible;
- }
- .screenshot_popup_modal_content.es_fullscreen .screenshot_popup_modal_footer > .btn_medium {
- 	opacity: 0;
- 	transition: opacity 0.25s ease-in-out;
- }
- .screenshot_popup_modal_content.es_fullscreen .screenshot_popup_modal_footer:hover > .btn_medium {
- 	opacity: 1;
- }
- .screenshot_popup_modal_content.es_fullscreen .screenshot_popup_modal_footer > div:first-child {
- 	display: inline-block;
- 	background: rgba(103, 193, 245, 0.2);
- 	border-radius: 100px;
- 	padding: 0 1em;
- }
- .screenshot_popup_modal_content.es_fullscreen .screenshot_popup_modal_footer > .previous:before {
- 	content: '';
- 	position: absolute;
- 	left: 0;
- 	bottom: 0;
- 	width: 200%;
- 	height: 10000%;
- }
- @keyframes es_screenshot_popup_modal_hook {
- 	from {
- 		opacity: 0.99;
- 	}
- 	to {
- 		opacity: 1;
- 	}
- }
- .screenshot_popup_modal {
- 	animation-duration: 0.001s;
- 	animation-name: es_screenshot_popup_modal_hook;
- }
+.es_fullscreen_toggle {
+	position: absolute;
+	right: 18%;
+	top: 0;
+}
+.es_fullscreen_toggle i {
+	display: block;
+	background-image: url('data:image/gif;base64,R0lGODlhEAAgAIABAP///////yH5BAEAAAEALAAAAAAQACAAAAJAjH+gC+jB1HNxpmqjnHVz31iQOIoh5D0Spmom+y0kypDaOWf2hVMNjLi9asNUTFZECpO9FjIDDLqOvyYvscsVAAA7');
+	background-position: top left;
+	width: 16px;
+	height: 16px;
+	margin: 5px;
+}
+.screenshot_popup_modal_content.es_fullscreen .es_fullscreen_toggle i {
+	background-position: bottom left;
+}
+.screenshot_popup_modal_content.es_fullscreen {
+	padding: 0;
+	width: 100%;
+	/* fullscreen fix for Chrome */
+	height: 100%;
+}
+.screenshot_popup_modal_content.es_fullscreen .screenshot_popup_modal_title {
+	/* position: absolute; */
+	display: none;
+}
+.screenshot_popup_modal_content.es_fullscreen .screenshot_img_ctn {
+	width: 100%;
+	height: 100%;
+}
+.screenshot_popup_modal_content.es_fullscreen .screenshot_img_ctn > img {
+	max-width: 100% !important;
+	max-height: 100% !important;
+	object-fit: scale-down;
+	width: 100%;
+	height: 100%;
+}
+.screenshot_popup_modal_content.es_fullscreen .screenshot_popup_modal_footer {
+	position: absolute;
+	width: 100%;
+	bottom: 0;
+	overflow: visible;
+}
+.screenshot_popup_modal_content.es_fullscreen .screenshot_popup_modal_footer > .btn_medium {
+	opacity: 0;
+	transition: opacity 0.25s ease-in-out;
+}
+.screenshot_popup_modal_content.es_fullscreen .screenshot_popup_modal_footer:hover > .btn_medium {
+	opacity: 1;
+}
+.screenshot_popup_modal_content.es_fullscreen .screenshot_popup_modal_footer > div:first-child {
+	display: inline-block;
+	background: rgba(103, 193, 245, 0.2);
+	border-radius: 100px;
+	padding: 0 1em;
+}
+.screenshot_popup_modal_content.es_fullscreen .screenshot_popup_modal_footer > .previous:before {
+	content: '';
+	position: absolute;
+	left: 0;
+	bottom: 0;
+	width: 200%;
+	height: 10000%;
+}
+@keyframes es_screenshot_popup_modal_hook {
+	from {
+		opacity: 0.99;
+	}
+	to {
+		opacity: 1;
+	}
+}
+.screenshot_popup_modal {
+	animation-duration: 0.001s;
+	animation-name: es_screenshot_popup_modal_hook;
+}
 
 /***************************************
  * Store and Community

--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -1230,6 +1230,82 @@ input[type=checkbox].es_dlc_selection:checked + label {
 }
 
 /***************************************
+ * App pages
+ * add_fullscreen_screenshots_button()
+ **************************************/
+ .es_fullscreen_toggle {
+ 	position: absolute;
+ 	right: 18%;
+ 	top: 0;
+ }
+ .es_fullscreen_toggle i {
+ 	display: block;
+ 	background-image: url('data:image/gif;base64,R0lGODlhEAAgAIABAP///////yH5BAEAAAEALAAAAAAQACAAAAJAjH+gC+jB1HNxpmqjnHVz31iQOIoh5D0Spmom+y0kypDaOWf2hVMNjLi9asNUTFZECpO9FjIDDLqOvyYvscsVAAA7');
+ 	background-position: top left;
+ 	width: 16px;
+ 	height: 16px;
+ 	margin: 5px;
+ }
+ .screenshot_popup_modal_content.es_fullscreen .es_fullscreen_toggle i {
+ 	background-position: bottom left;
+ }
+ .screenshot_popup_modal_content.es_fullscreen {
+ 	padding: 0;
+ 	width: 100%; /* fullscreen fix for Chrome */
+ 	height: 100%;
+ }
+ .screenshot_popup_modal_content.es_fullscreen .screenshot_popup_modal_title {
+ 	/* position: absolute; */
+ 	display: none;
+ }
+ .screenshot_popup_modal_content.es_fullscreen .screenshot_img_ctn > img {
+ 	max-width: 100% !important;
+ 	max-height: 100% !important;
+ 	object-fit: scale-down;
+ 	width: 100%;
+ 	height: 100%;
+ }
+ .screenshot_popup_modal_content.es_fullscreen .screenshot_popup_modal_footer {
+ 	position: absolute;
+ 	width: 100%;
+ 	bottom: 0;
+ 	overflow: visible;
+ }
+ .screenshot_popup_modal_content.es_fullscreen .screenshot_popup_modal_footer > .btn_medium {
+ 	opacity: 0;
+ 	transition: opacity 0.25s ease-in-out;
+ }
+ .screenshot_popup_modal_content.es_fullscreen .screenshot_popup_modal_footer:hover > .btn_medium {
+ 	opacity: 1;
+ }
+ .screenshot_popup_modal_content.es_fullscreen .screenshot_popup_modal_footer > div:first-child {
+ 	display: inline-block;
+ 	background: rgba(103, 193, 245, 0.2);
+ 	border-radius: 100px;
+ 	padding: 0 1em;
+ }
+ .screenshot_popup_modal_content.es_fullscreen .screenshot_popup_modal_footer > .previous:before {
+ 	content: '';
+ 	position: absolute;
+ 	left: 0;
+ 	bottom: 0;
+ 	width: 200%;
+ 	height: 10000%;
+ }
+ @keyframes es_screenshot_popup_modal_hook {
+ 	from {
+ 		opacity: 0.99;
+ 	}
+ 	to {
+ 		opacity: 1;
+ 	}
+ }
+ .screenshot_popup_modal {
+ 	animation-duration: 0.001s;
+ 	animation-name: es_screenshot_popup_modal_hook;
+ }
+
+/***************************************
  * Store and Community
  * add_language_warning(),
  * add_fake_country_code_warning()

--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -5343,6 +5343,52 @@ function dlc_data_from_site(appid) {
 	}
 }
 
+function add_fullscreen_screenshots_button() {
+	function es_toggleFullScreen(element = doc.documentElement) {
+		var doc = window.document;
+		var requestFullScreen = element.requestFullscreen || element.mozRequestFullScreen || element.webkitRequestFullScreen;
+		var cancelFullScreen = doc.exitFullscreen || doc.mozCancelFullScreen || doc.webkitExitFullscreen;
+		if (!doc.fullscreenElement && !doc.mozFullScreenElement && !doc.webkitFullscreenElement) {
+			requestFullScreen.call(element);
+		} else {
+			cancelFullScreen.call(doc);
+		}
+	}
+
+	function es_fullScreenChangeHandler(event) {
+		var es_fullscreenElement = document.fullscreenElement || document.mozFullScreenElement || document.webkitFullscreenElement;
+		if (es_fullscreenElement) {
+			if (es_fullscreenElement.classList.contains("screenshot_popup_modal_content")) {
+				$(".screenshot_popup_modal_content").addClass("es_fullscreen");
+			}
+		} else {
+			$(".screenshot_popup_modal_content").removeClass("es_fullscreen");
+		}
+	}
+
+	if ("onfullscreenchange" in document) {
+		document.addEventListener("fullscreenchange", es_fullScreenChangeHandler, false);
+	}
+	if ("onmozfullscreenchange" in document) {
+		document.addEventListener("mozfullscreenchange", es_fullScreenChangeHandler, false);
+	}
+	if ("onwebkitfullscreenchange" in document) {
+		document.addEventListener("webkitfullscreenchange", es_fullScreenChangeHandler, false);
+	}
+
+	document.addEventListener("animationstart", function(event) {
+		if (event.animationName === "es_screenshot_popup_modal_hook") {
+			$('<div class="btnv6_blue_hoverfade btn_medium es_fullscreen_toggle"><i></i></div>').appendTo(".screenshot_popup_modal_footer");
+			$(".es_fullscreen_toggle").css({
+				"right": `calc(${$(".screenshot_popup_modal_footer > .next").outerWidth()}px + 0.5em)`
+			});
+			$(".es_fullscreen_toggle").on("click", function() {
+				es_toggleFullScreen($(".screenshot_popup_modal_content")[0]);
+			});
+		}
+	}, false);
+}
+
 function survey_data_from_site(appid) {
 	storage.get(function(settings) {
 		if (settings.show_apppage_surveys === undefined) { settings.show_apppage_surveys = true; storage.set({'show_apppage_surveys': settings.show_apppage_surveys}); }
@@ -8641,6 +8687,7 @@ $(document).ready(function(){
 							display_coupon_message(appid);
 							show_pricing_history(appid, "app");
 							dlc_data_from_site(appid);
+							add_fullscreen_screenshots_button();
 
 							drm_warnings("app");
 							add_metacritic_userscore();


### PR DESCRIPTION
Simple button which activates fullscreen mode to comfortly view screenshots at store pages.

**How it looks like:**
![stf2](https://user-images.githubusercontent.com/6583664/39699651-cd5b235c-5202-11e8-9b08-93982b864c78.png)
![stf1](https://user-images.githubusercontent.com/6583664/39699654-cfb6c20a-5202-11e8-8ae9-38a1c32e645e.png)

**Try out**
You can try it by installing userscript from here:
https://gist.github.com/thomas-ashcraft/00e58a0141fda12199d5e1fdee821ecf
Code is completely the same.

**Technical notes:**

I have tested unpacked ES with that code in Chrome. Everything works perfecrly. The code in userscript also have been tested in Firefox. Also works perfect.

Buttons at the fullscreen mode visible only when footer is `:hover`.

"Previous" button also triggers by pressing left part of the screen.

There is 3 prefixes around: `moz`, `webkit` and `ms`. I didnt included `ms` because it only for IE, and ES are not supposed to work with it. In case ES eventually comes to Edge: it uses `webkit` prefix.

In perfect world there is should be a `:fullscreen` pseudo-class. But right now for a proper working, CSS should be written completely separately for every each prefix. Should not stack through comma to write one rule for a different prefixes. To avoid multiply CSS strings I used `fullscreenchange` event hook to add/remove custom `es_fullscreen` class which I basically used as `:fullscreen` pseudo. Like if it was finally properly implemented by all browsers.

There is one more trick: css hook which triggers JS code which applies button every time `screenshot_popup_modal` appears in DOM. Theoretically there is may be a way to apply this button only once if someone knows a way how to edit `screenshot_popup_modal` template at internal Steam's functions. But it's not a fact.
