### PR TITLE
Implementing UncensorPat.ch integration for store search and game pages

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -981,6 +981,69 @@ function validate_price (priceText, event) {
 	var price = Number(priceText);
 	return !(Number.isNaN(price));
 }
+ 
+var uncensorpatch_module = (function () {
+	var uncensor_json = null;
+	
+	var pub = {};
+
+	pub.apply_uncensor_node = function (node) {
+		storage.get(function (settings) {
+			if (settings.show_uncensorpatch_info) {
+				if(uncensor_json === null) pub.get_json();
+				else {
+					var appid = parseInt($(node).attr("data-ds-appid"));
+					if ($("#es_uncensor_exists").is(".checked")) {
+						if ($.inArray(appid, uncensor_json["exists"]) === -1) $(node).hide();
+					}
+					if ($("#es_uncensor_unsure").is(".checked")) {
+						if (($.inArray(appid, uncensor_json["exists"]) > -1)
+						| ($.inArray(appid, uncensor_json["not_exists"]) > -1)) {
+							$(node).hide();
+						}
+					}
+					if ($("#es_uncensor_not_exists").is(".checked")) {
+						if ($.inArray(appid, uncensor_json["not_exists"]) === -1) $(node).hide();
+					}
+					if ($(document).height() <= $(window).height()) {
+						load_search_results()
+					}
+				}
+			}
+		});
+	}
+
+	pub.apply_uncensor = function () {
+		storage.get(function (settings) {
+			if (settings.show_uncensorpatch_info) {
+				if(uncensor_json === null) pub.get_json();
+				else {
+					$(".search_result_row").each(function() {
+						$(this).css("display", "block");
+						pub.apply_uncensor_node(this);
+					});
+				}
+			}
+		});
+	}
+
+	pub.get_json = function () {
+		storage.get(function (settings) {
+			if (settings.show_uncensorpatch_info) {
+				if(uncensor_json === null) {
+					$.getJSON('https://www.uncensorpat.ch/api/get-data', function(ret_json) {
+						uncensor_json = ret_json;
+						pub.apply_uncensor();
+					});
+				} else {
+					pub.apply_uncensor();
+				}
+			}
+		});
+	}
+
+	return pub;
+}());
 
 function hexToRgb(hex) {
 	var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
@@ -3406,6 +3469,87 @@ function add_hide_buttons_to_search() {
 		}
 	});
 }
+ 
+function add_uncensor_buttons_to_search() {
+	storage.get(function(settings) {
+		if (settings.show_uncensorpatch_info) {
+			if (settings.uncensor_exists === undefined) { settings.uncensor_exists = false; storage.set({'uncensor_exists': settings.uncensor_exists}); }
+			if (settings.uncensor_unsure === undefined) { settings.uncensor_unsure = false; storage.set({'uncensor_unsure': settings.uncensor_unsure}); }
+			if (settings.uncensor_not_exists === undefined) { settings.uncensor_not_exists = false; storage.set({'uncensor_not_exists': settings.uncensor_not_exists}); }
+			
+			$("#advsearchform").find(".rightcol").prepend(`
+				<div class='block' id='es_uncensor_menu'>
+					<div class='block_header'><div>` + localized_strings.uncensor.narrow_by + `</div></div>
+					<div class='block_content block_content_inner' style='height: 90px;' id='es_uncensor_options'>
+						<div class='tab_filter_control' id='es_uncensor_exists'>
+							<div class='tab_filter_control_checkbox'></div>
+							<span class='tab_filter_control_label'>` + localized_strings.uncensor.exists + `</span>
+						</div>
+						<div class='tab_filter_control' id='es_uncensor_unsure'>
+							<div class='tab_filter_control_checkbox'></div>
+							<span class='tab_filter_control_label'>` + localized_strings.uncensor.unsure + `</span>
+						</div>
+						<div class='tab_filter_control' id='es_uncensor_not_exists'>
+							<div class='tab_filter_control_checkbox'></div>
+							<span class='tab_filter_control_label'>` + localized_strings.uncensor.not_exists + `</span>
+						</div>
+					</div>
+				</div>
+			`);
+
+			if (settings.uncensor_exists) {
+				$("#es_uncensor_exists").addClass("checked");
+			}
+			if (settings.uncensor_unsure) {
+				$("#es_uncensor_unsure").addClass("checked");
+			}
+			if (settings.uncensor_not_exists) {
+				$("#es_uncensor_not_exists").addClass("checked");
+			}
+
+			function add_uncensor_buttons_to_search_click() {
+				uncensorpatch_module.get_json();
+			}
+
+			if (settings.uncensor_exists | settings.uncensor_unsure | settings.uncensor_not_exists) {
+				add_uncensor_buttons_to_search_click();
+			}
+
+			$("#es_uncensor_exists").click(function() {
+				if ($("#es_uncensor_exists").hasClass("checked")) {
+					$("#es_uncensor_exists").removeClass("checked");
+					storage.set({'uncensor_exists': false });
+				} else {
+					$("#es_uncensor_exists").addClass("checked");
+					storage.set({'uncensor_exists': true });
+				}
+				add_uncensor_buttons_to_search_click();
+			});
+
+			$("#es_uncensor_unsure").click(function() {
+				if ($("#es_uncensor_unsure").hasClass("checked")) {
+					$("#es_uncensor_unsure").removeClass("checked");
+					storage.set({'uncensor_unsure': false });
+				} else {
+					$("#es_uncensor_unsure").addClass("checked");
+					storage.set({'uncensor_unsure': true });
+				}
+				add_uncensor_buttons_to_search_click();
+			});
+
+			$("#es_uncensor_not_exists").click(function() {
+				if ($("#es_uncensor_not_exists").hasClass("checked")) {
+					$("#es_uncensor_not_exists").removeClass("checked");
+					storage.set({'uncensor_not_exists': false });
+				} else {
+					$("#es_uncensor_not_exists").addClass("checked");
+					storage.set({'uncensor_not_exists': true });
+				}
+				add_uncensor_buttons_to_search_click();
+			});
+		}
+	});
+}
 
 function set_homepage_tab() {
 	storage.get(function(settings) {
@@ -3938,6 +4082,31 @@ function add_hltb_info(appid) {
 			}
 		});
 	}
+}
+ 
+function add_uncensor_patch_info(appid) {
+	storage.get(function(settings) {
+		if (settings.show_uncensorpatch_info) {
+			$.getJSON('https://www.uncensorpat.ch/api/game/'+appid, function(game_uncensor_json) {
+				uncensor_patch_html = "<div class='block responsive_apppage_details_right heading'>" + localized_strings.uncensor.title + "</div>"
+					+ "<div class='block game_details underlined_links'>"
+					+ "<div class='block_content'><div class='block_content_inner'><div class='details_block'>"
+					+ "<b>" + localized_strings.uncensor.status + " </b>";
+				if (game_uncensor_json["exists"]) {
+					uncensor_patch_html += localized_strings.uncensor.exists + "</div>"
+						+ "<a class='linkbar' href='https://www.uncensorpat.ch/game/"+appid+"' target='_blank'>"
+						+ localized_strings.uncensor.visit
+						+ " <img src='https://steamstore-a.akamaihd.net/public/images/v5/ico_external_link.gif' border='0' align='bottom'></a>";
+				} else if (game_uncensor_json["investigated"]) {
+					uncensor_patch_html += localized_strings.uncensor.not_exists + "</div>";
+				} else {
+					uncensor_patch_html += localized_strings.uncensor.unsure + "</div>";
+				}
+				uncensor_patch_html += "</div></div></div>";
+				$("div.game_details:first").after(uncensor_patch_html);
+			});
+		}
+	});
 }
 
 // Add link to game pages on pcgamingwiki.com
@@ -6559,6 +6728,7 @@ function bind_ajax_content_highlighting() {
 					endless_scrolling();
 					start_highlights_and_tags();
 					process_early_access();
+					uncensorpatch_module.apply_uncensor(node);
 				}
 
 				if ($(node).children('div')[0] && $(node).children('div')[0].classList.contains("blotter_day")) {
@@ -6581,6 +6751,7 @@ function bind_ajax_content_highlighting() {
 					check_early_access(node);
 					apply_rate_filter(node);
 					apply_price_filter(node);
+					uncensorpatch_module.apply_uncensor_node(node);
 				}
 
 				if (node.classList && node.classList.contains("market_listing_row_link")) highlight_market_items();
@@ -8647,6 +8818,7 @@ $(document).ready(function(){
 
 							add_widescreen_certification(appid);
 							add_hltb_info(appid);
+							add_uncensor_patch_info(appid);
 							add_steam_client_link(appid);
 							add_pcgamingwiki_link(appid);
 							add_steamcardexchange_link(appid);
@@ -8726,6 +8898,7 @@ $(document).ready(function(){
 						case /^\/search\/.*/.test(path):
 							endless_scrolling();
 							add_hide_buttons_to_search();
+							add_uncensor_buttons_to_search();
 							add_exclude_tags_to_search();
 							break;
 

--- a/js/options.js
+++ b/js/options.js
@@ -104,6 +104,7 @@ var settings_defaults = {
 	"show_early_access": true,
 	"show_alternative_linux_icon": false,
 	"show_itad_button": false,
+	"show_uncensorpatch_info": false,
 	"skip_got_steam": false,
 	
 	"hideinstallsteambutton": false,

--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -288,6 +288,15 @@
         "help": "Click here to help",
         "wrong": "Wrong game?"
     },
+    "uncensor": {
+        "title": "Uncensor Patch Details",
+        "narrow_by": "Filter by uncensor patch",
+        "status": "Uncensor patch status:",
+        "visit": "View details on UncensorPat.ch",
+        "exists": "Available",
+        "unsure": "Unsure",
+        "not_exists": "Doesn't exist"
+    },
     "library": {
         "in_library": "In Library",
         "error_loading_library": "Couldn't load your library.",
@@ -421,6 +430,7 @@
         "show_badge_progress": "Show apps badge progress on store pages",
         "show_wishlist_link": "Show a Wishlist link on profiles",
         "show_wishlist_count": "Show the number of items on Wishlist",
+        "show_uncensorpatch_info": "Show UncensorPat.ch info and filters (18+ only)",
         "lang": {
             "english": "English",
             "brazilian": "Portuguese-Brazil",

--- a/options.html
+++ b/options.html
@@ -230,6 +230,7 @@
 				<li><input type="checkbox" id="show_steamchart_info" data-setting="show_steamchart_info"><label for="show_steamchart_info" id="store_steamchart_info_text" data-locale-text="options.show_steamchart_info">Show SteamCharts.com info</label></li>
 				<li><input type="checkbox" id="show_steamspy_info" data-setting="show_steamspy_info"><label for="show_steamspy_info" id="store_steamspy_info_text" data-locale-text="options.show_steamspy_info">Show steamspy.com info</label></li>
 				<li><input type="checkbox" id="show_itad_button" data-setting="show_itad_button"><label for="show_itad_button" id="show_itad_button_text" data-locale-text="itad.option">Show menu option to sync data to IsThereAnyDeal.com</label>
+				<li><input type="checkbox" id="show_uncensorpatch_info" data-setting="show_uncensorpatch_info"><label for="show_uncensorpatch_info" id="store_steamspy_info_text" data-locale-text="options.show_uncensorpatch_info">Show UncensorPat.ch info and filters (18+ only)</label></li>
 				</ul>
 			</div>
 


### PR DESCRIPTION
This set of changes adds integration into https://www.UncensorPat.ch into EnhancedSteam, allowing for filtering by uncensor patch in the search page, and showing uncensor patch information on the individual game store pages. Given the nature of the data, it defaults to being off and is therefore opt-in.

I have trialled the changes and it seems functional, robust, and responsive.

I see that most API calls are done through the EnhancedSteam API, these changes just use direct API calls to UncensorPat.ch, but I'd be happy to collaborate in order to integrate my API better with EnhancedSteam (it was created for this sole purpose, after all).

This is the same commit information from #1609 without all of the spurious changes that occurred when I attempted to amend the commit author - I really can't apologise enough about that.